### PR TITLE
Live festival data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ Figma: ​​https://www.figma.com/file/jXiy6tmnOk2jeyhyI6hED0/CPSC-455---Design
 
 
 
+## How to run
+# Frontend, download docker desktop, run it, then open visual studio code
+1. `cd react-app`
+2. `npm i`
+3. `npm start`
+
+# Backend
+1. Make sure you have .env file
+2. `cd server`
+3. `npm i`
+4. `npm run watch`

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -8,11 +8,13 @@
       "name": "festival-fanatic",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.8.2",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -2995,6 +2997,29 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
+      "integrity": "sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3669,6 +3694,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3840,6 +3874,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -8197,6 +8236,14 @@
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "dependencies": {
         "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/hoopy": {
@@ -13734,6 +13781,49 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -13894,6 +13984,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/regenerate": {
@@ -14111,6 +14217,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -15539,6 +15650,14 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -18503,6 +18622,17 @@
         "source-map": "^0.7.3"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
+      "integrity": "sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -18984,6 +19114,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -19155,6 +19294,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -22328,6 +22472,14 @@
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "requires": {
         "@babel/runtime": "^7.7.6"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hoopy": {
@@ -26182,6 +26334,26 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -26303,6 +26475,20 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -26466,6 +26652,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -27514,6 +27705,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -3,11 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.8.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"

--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -9,7 +9,15 @@ function App() {
       <Navbar />
       <div className="description-container">
         <p>Find festivals based on your spotify listening with one click</p>
-        <button className="get-started-btn" onClick={() => {navigate("/login")}}>Log in with Spotify</button>
+        <button className="get-started-btn" onClick={(e) => {
+          e.preventDefault();
+          window.location.href = 'http://localhost:3001/login';
+
+          // fetch("http://localhost:3001/login", {
+          //   method: 'GET', credentials: 'same-origin', 'Access-Control-Allow-Origin': "*",
+          // })
+        }}
+        >Log in with Spotify</button>
       </div>
     </div>
   );

--- a/react-app/src/components/Navbar/Navbar.jsx
+++ b/react-app/src/components/Navbar/Navbar.jsx
@@ -10,6 +10,10 @@ export default function Navbar() {
       <Link to="/login" className="nav-link">
         Log in
       </Link>
+      {/* Logout of spotify AKA invalidate the tokens: https://stackoverflow.com/questions/24408444/how-to-logout-user-from-spotify-after-authorization-and-web-api-call-is-over */}
+      <a href="https://accounts.spotify.com/en/logout" target="_blank" className="nav-link" rel="noreferrer">
+        Log out
+      </a>
     </nav>
   );
 }

--- a/react-app/src/index.js
+++ b/react-app/src/index.js
@@ -7,16 +7,20 @@ import Results from "./routes/results/results";
 import TopArtists from "./routes/top-artists/top-artists";
 import LogIn from "./routes/login/login";
 import DetailedResults from "./routes/detailed-results/detailed-results";
+import { Provider } from 'react-redux';
+import { store } from "./redux/store";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <BrowserRouter>
-    <Routes>
-      <Route path="/" element={<App />} />
-      <Route path="login" element={<LogIn/>}/>
-      <Route path="results" element={<Results />} />
-      <Route path="top-artists" element={<TopArtists />} />
-      <Route path="results/detailed-results" element={<DetailedResults />} />
-    </Routes>
-  </BrowserRouter>
+  <Provider store={store}>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="login" element={<LogIn />} />
+        <Route path="results" element={<Results />} />
+        <Route path="top-artists" element={<TopArtists />} />
+        <Route path="results/detailed-results" element={<DetailedResults />} />
+      </Routes>
+    </BrowserRouter>
+  </Provider>
 );

--- a/react-app/src/redux/festivals/reducer.js
+++ b/react-app/src/redux/festivals/reducer.js
@@ -1,0 +1,17 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { dummyFestivals } from "../../utilities/festivalResultData";
+
+
+const INITIAL_STATE = {
+    // TODO: festivals should be blank in the beginning
+    festivals: dummyFestivals,
+    error: null
+}
+
+const festivalsSlice = createSlice({
+    name: 'festivals',
+    initialState: INITIAL_STATE,
+
+});
+
+export default festivalsSlice.reducer;

--- a/react-app/src/redux/festivals/reducer.js
+++ b/react-app/src/redux/festivals/reducer.js
@@ -1,16 +1,33 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { dummyFestivals } from "../../utilities/festivalResultData";
-
+import { REQUEST_STATE } from '../utils';
+import { getUpcomingArtistEventsAsync } from './thunks';
 
 const INITIAL_STATE = {
     // TODO: festivals should be blank in the beginning
-    festivals: dummyFestivals,
+    festivals: [],
+    getEventsStatus: null,
     error: null
 }
 
 const festivalsSlice = createSlice({
     name: 'festivals',
     initialState: INITIAL_STATE,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(getUpcomingArtistEventsAsync.pending, (state) => {
+                state.getEventsStatus = REQUEST_STATE.PENDING;
+                state.error = null;
+            })
+            .addCase(getUpcomingArtistEventsAsync.fulfilled, (state, action) => {
+                state.getEventsStatus = REQUEST_STATE.FULFILLED;
+                state.festivals = action.payload;
+            })
+            .addCase(getUpcomingArtistEventsAsync.rejected, (state, action) => {
+                state.getEventsStatus = REQUEST_STATE.REJECTED;
+                state.error = action.error;
+            })
+    }
 
 });
 

--- a/react-app/src/redux/festivals/service.js
+++ b/react-app/src/redux/festivals/service.js
@@ -1,0 +1,26 @@
+
+const getUpcomingArtistEvents = async (artistName) => {
+
+    const response = await fetch(`http://localhost:3001/bandsintown/all-events`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+        const errorMsg = data?.message;
+        throw new Error(errorMsg)
+    }
+
+    return data;
+};
+
+
+
+const festivalService = {
+    getUpcomingArtistEvents
+}
+
+export default festivalService;

--- a/react-app/src/redux/festivals/service.js
+++ b/react-app/src/redux/festivals/service.js
@@ -2,9 +2,13 @@
 const getUpcomingArtistEvents = async (artistName) => {
 
     const response = await fetch(`http://localhost:3001/bandsintown/all-events`, {
+        // TODO: Investigate best way to store JWT token for security 
+        // https://stackoverflow.com/questions/27067251/where-to-store-jwt-in-browser-how-to-protect-against-csrf?rq=1
         method: 'GET',
+        // Need credentials to pass cookie data into request
+        credentials: "include",
         headers: {
-            'Content-Type': 'application/json'
+            'Access-Control-Allow-Origin': "http://localhost:3000",
         },
     });
 

--- a/react-app/src/redux/festivals/thunks.js
+++ b/react-app/src/redux/festivals/thunks.js
@@ -1,0 +1,13 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import FestivalsService from './service';
+
+export const actionTypes = {
+    GET_EVENTS: 'festivals/getUpcomingArtistEvents',
+};
+
+export const getUpcomingArtistEventsAsync = createAsyncThunk(
+    actionTypes.GET_EVENTS,
+    async (artistName) => {
+        return await FestivalsService.getUpcomingArtistEvents(artistName);
+    }
+);

--- a/react-app/src/redux/spotify/reducer.js
+++ b/react-app/src/redux/spotify/reducer.js
@@ -1,0 +1,41 @@
+import { createSlice } from '@reduxjs/toolkit';
+// import { REQUEST_STATE } from '../utils';
+import { spotifyUserTopItems } from '../../utilities/spotify-user-top-items';
+
+const INITIAL_STATE = {
+    // TODO: spotifyTopArtists should be blank in the beginning
+    spotifyTopArtists: spotifyUserTopItems,
+    // getSpotifyTopArtists: REQUEST_STATE.IDLE,
+    // addUser: REQUEST_STATE.IDLE,
+    error: null
+}
+
+const spotifySlice = createSlice({
+    name: 'spotify',
+    initialState: INITIAL_STATE,
+    // reducers: {
+    //     getSpotifyTopArtistsAsync: (state, action) => {
+    //         state.spotifyTopArtists.push(action.payload)
+    //     }
+    // },
+    // extraReducers: (builder) => {
+    //     // TODO: Finish making the requests to Spotify
+    //     builder
+    //         .addCase(getSpotifyTopArtistsAsync.pending, (state) => {
+    //             state.getUsers = REQUEST_STATE.PENDING;
+    //             state.error = null;
+    //         })
+    //         .addCase(getSpotifyTopArtistsAsync.fulfilled, (state, action) => {
+    //             state.getUsers = REQUEST_STATE.FULFILLED;
+    //             state.spotifyTopArtists = action.payload;
+    //         })
+    //         .addCase(getSpotifyTopArtistsAsync.rejected, (state, action) => {
+    //             state.getUsers = REQUEST_STATE.REJECTED;
+    //             state.error = action.error;
+    //         })
+    // }
+});
+
+// export const { addSpotifyTopArtists } = spotifySlice.actions;
+
+export default spotifySlice.reducer;

--- a/react-app/src/redux/store.js
+++ b/react-app/src/redux/store.js
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import spotifyReducer from './spotify/reducer';
+import festivalsReducer from './festivals/reducer';
+
+export const store = configureStore({
+  reducer: {
+    spotify: spotifyReducer,
+    festivals: festivalsReducer
+  },
+  devTools: true
+});

--- a/react-app/src/redux/utils.js
+++ b/react-app/src/redux/utils.js
@@ -1,0 +1,6 @@
+export const REQUEST_STATE = {
+    IDLE: 'IDLE',
+    PENDING: 'PENDING',
+    FULFILLED: 'FULFILLED',
+    REJECTED: 'REJECTED'
+  };

--- a/react-app/src/routes/results/results.jsx
+++ b/react-app/src/routes/results/results.jsx
@@ -1,17 +1,24 @@
 import Navbar from "../../components/Navbar/Navbar";
 import FestivalCard from "../../components/FestivalCard/FestivalCard";
 import "./results.css";
-import { dummyFestivals } from "../../utilities/festivalResultData";
-
+import { useSelector } from "react-redux";
 
 export default function Results() {
+  const dummyFestivals = useSelector(
+    (state) => state.festivals.festivals
+  );
   return (
     <>
       <Navbar />
       <h2>Your results</h2>
-      {dummyFestivals.map((festival) => (
-        <FestivalCard festival={festival} key={festival.id} />
-      ))}
+
+      {dummyFestivals ? (
+        dummyFestivals.map((festival) => (
+          <FestivalCard festival={festival} key={festival.id} />
+        ))
+      ) : (
+        <p>Loading or Error, No data {JSON.stringify(dummyFestivals)}</p>
+      )}
     </>
   );
 }

--- a/react-app/src/routes/results/results.jsx
+++ b/react-app/src/routes/results/results.jsx
@@ -1,9 +1,20 @@
 import Navbar from "../../components/Navbar/Navbar";
 import FestivalCard from "../../components/FestivalCard/FestivalCard";
 import "./results.css";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from 'react-redux';
+import { getUpcomingArtistEventsAsync } from "../../redux/festivals/thunks";
+import React, { useEffect } from 'react';
+
 
 export default function Results() {
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getUpcomingArtistEventsAsync("Illenium"));
+  }, []);
+
+
   const dummyFestivals = useSelector(
     (state) => state.festivals.festivals
   );
@@ -12,13 +23,18 @@ export default function Results() {
       <Navbar />
       <h2>Your results</h2>
 
-      {dummyFestivals ? (
+
+{/* TODO: Update dummy festivals */}
+      {JSON.stringify(dummyFestivals)}
+
+
+      {/* {dummyFestivals ? (
         dummyFestivals.map((festival) => (
           <FestivalCard festival={festival} key={festival.id} />
         ))
       ) : (
         <p>Loading or Error, No data {JSON.stringify(dummyFestivals)}</p>
-      )}
+      )} */}
     </>
   );
 }

--- a/react-app/src/routes/top-artists/top-artists.jsx
+++ b/react-app/src/routes/top-artists/top-artists.jsx
@@ -1,16 +1,18 @@
 import ArtistCard from "../../components/ArtistCard/ArtistCard";
 import Navbar from "../../components/Navbar/Navbar";
-import { spotifyUserTopItems } from "../../utilities/spotify-user-top-items";
+import { useSelector } from "react-redux";
 
 export default function TopArtists() {
+    const spotifyUserTopItems = useSelector(
+        (state) => state.spotify.spotifyTopArtists
+    );
     return (
         <>
             <Navbar />
             <h2>Your Top Artists</h2>
-            {spotifyUserTopItems.items.map((artist) =>
+            {spotifyUserTopItems.items.map((artist) => (
                 <ArtistCard artist={artist} key={artist.id} />
-
-            )}
+            ))}
         </>
     );
 }

--- a/react-app/src/utilities/bandsintown-artist-event-RAW-data.js
+++ b/react-app/src/utilities/bandsintown-artist-event-RAW-data.js
@@ -1,0 +1,2576 @@
+const bandsintownArtistEvent = [
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103208875?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Italy",
+            "city": "Lucca",
+            "latitude": "43.84125539999999",
+            "name": "Summer Festival Lucca",
+            "location": "Lucca, Italy",
+            "region": "",
+            "longitude": "10.5028785"
+        },
+        "starts_at": "2022-07-31T19:00:00",
+        "artist": {
+            "thumb_url": "https://photos.bandsintown.com/thumb/11112851.jpeg",
+            "mbid": "e0140a67-e4d1-4f13-8a01-364355bee46e",
+            "facebook_page_url": "http://www.facebook.com/67253243887",
+            "image_url": "https://photos.bandsintown.com/large/11112851.jpeg",
+            "tracker_count": 5008277,
+            "tracking": [],
+            "upcoming_event_count": 71,
+            "url": "https://www.bandsintown.com/a/307871?came_from=267&app_id=6e37869bb2e8504c0160c0ddcbd8c8aa",
+            "support_url": "",
+            "name": "Justin Bieber",
+            "options": {
+                "display_listen_unit": false
+            },
+            "links": [
+                {
+                    "type": "website",
+                    "url": "http://justinbiebermusic.com"
+                },
+                {
+                    "type": "facebook",
+                    "url": "https://www.facebook.com/JustinBieber/"
+                },
+                {
+                    "type": "newsletter",
+                    "url": "https://www.justinbiebermusic.com/#mailing-list"
+                },
+                {
+                    "type": "instagram",
+                    "url": "https://www.instagram.com/justinbieber/"
+                },
+                {
+                    "type": "twitter",
+                    "url": "https://twitter.com/justinbieber"
+                },
+                {
+                    "type": "snapchat",
+                    "url": "https://www.snapchat.com/add/rickthesizzler"
+                },
+                {
+                    "type": "spotify",
+                    "url": "https://open.spotify.com/artist/1uNFoZAHBGtllmzznpCI3s?si=-yzHn9phTteRobACi-7TZQ"
+                },
+                {
+                    "type": "itunes",
+                    "url": "https://itunes.apple.com/us/artist/justin-bieber/320569549"
+                },
+                {
+                    "type": "amazon",
+                    "url": "https://music.amazon.com/artists/B002F0BWIM?tab=CATALOG"
+                },
+                {
+                    "type": "soundcloud",
+                    "url": "https://soundcloud.com/justinbieber"
+                },
+                {
+                    "type": "youtube",
+                    "url": "https://www.youtube.com/user/kidrauhl"
+                },
+                {
+                    "type": "vevo",
+                    "url": "https://www.youtube.com/user/JustinBieberVEVO"
+                },
+                {
+                    "type": "tumblr",
+                    "url": "https://justinbieber.tumblr.com/"
+                },
+                {
+                    "type": "iheart",
+                    "url": "https://www.iheart.com/artist/justin-bieber-44368/"
+                },
+                {
+                    "type": "store/merch",
+                    "url": "https://shop.justinbiebermusic.com/"
+                }
+            ],
+            "artist_optin_show_phone_number": false,
+            "id": "307871"
+        },
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Summer Festival Lucca",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103208875?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-07-31T19:00:00",
+        "on_sale_datetime": "",
+        "id": "103208875",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102987499?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Denmark",
+            "city": "Skanderborg",
+            "latitude": "56.01808579999999",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Skanderborg, Denmark",
+            "region": "",
+            "longitude": "9.8873416"
+        },
+        "starts_at": "2022-08-03T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102987499?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-08-03T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102987499",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102987512?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Sweden",
+            "city": "Malmö",
+            "latitude": "55.59001629999999",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Malmö, Sweden",
+            "region": "",
+            "longitude": "12.9887433"
+        },
+        "starts_at": "2022-08-05T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102987512?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-08-05T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102987512",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102987526?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Norway",
+            "city": "Trondheim",
+            "latitude": "63.4303894",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Trondheim, Norway",
+            "region": "",
+            "longitude": "10.3917799"
+        },
+        "starts_at": "2022-08-07T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102987526?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-08-07T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102987526",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102987528?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Finland",
+            "city": "Helsinki",
+            "latitude": "60.17495229999999",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Helsinki, Finland",
+            "region": "",
+            "longitude": "24.9432426"
+        },
+        "starts_at": "2022-08-09T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102987528?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-08-09T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102987528",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103198068?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Hungary",
+            "city": "Budapest Iii. Kerület",
+            "latitude": "47.54157",
+            "name": "Sziget Festival 2022",
+            "location": "Budapest III. kerület, Hungary",
+            "region": "",
+            "longitude": "19.04501"
+        },
+        "starts_at": "2022-08-12T19:00:00",
+        "festival_datetime_display_rule": "range",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "2022-08-10",
+        "bandsintown_plus": false,
+        "title": "Sziget Festival 2022",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103198068?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-08-12T19:00:00",
+        "on_sale_datetime": "",
+        "id": "103198068",
+        "ends_at": "",
+        "festival_end_date": "2022-08-15"
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102987550?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Brazil",
+            "city": "Rio De Janeiro",
+            "latitude": "-22.90642",
+            "name": "Rock in Rio 2022",
+            "location": "Rio de Janeiro, Brazil",
+            "region": "",
+            "longitude": "-43.18223"
+        },
+        "starts_at": "2022-09-04T17:00:00",
+        "festival_datetime_display_rule": "range",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "2022-09-02",
+        "bandsintown_plus": false,
+        "title": "Rock in Rio 2022",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102987550?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-09-04T17:00:00",
+        "on_sale_datetime": "",
+        "id": "102987550",
+        "ends_at": "",
+        "festival_end_date": "2022-09-11"
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102988693?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Chile",
+            "city": "Ñuñoa",
+            "latitude": "-33.4646281",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Ñuñoa, Chile",
+            "region": "",
+            "longitude": "-70.6106762"
+        },
+        "starts_at": "2022-09-07T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102988693?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-09-07T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102988693",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102988699?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Argentina",
+            "city": "La Plata",
+            "latitude": "-34.90798540000001",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "La Plata, Argentina",
+            "region": "",
+            "longitude": "-57.9422956"
+        },
+        "starts_at": "2022-09-10T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102988699?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-09-10T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102988699",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103198046?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Argentina",
+            "city": "La Plata",
+            "latitude": "-34.9137939",
+            "name": "Estadio Único Ciudad de La Plata",
+            "location": "La Plata, Argentina",
+            "region": "",
+            "longitude": "-57.9891083"
+        },
+        "starts_at": "2022-09-11T19:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103198046?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-09-11T19:00:00",
+        "on_sale_datetime": "",
+        "id": "103198046",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103345691?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Brazil",
+            "city": "Sao Paulo",
+            "latitude": "-23.5272725",
+            "name": "Justice Tour",
+            "location": "São Paulo, Brazil",
+            "region": "",
+            "longitude": "-46.678907400000014"
+        },
+        "starts_at": "2022-09-14T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justice Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103345691?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-09-14T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103345691",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102988703?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "South Africa",
+            "city": "Cape Town",
+            "latitude": "-33.904791",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Cape Town, South Africa",
+            "region": "",
+            "longitude": "18.4098451"
+        },
+        "starts_at": "2022-09-28T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102988703?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-09-28T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102988703",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102988714?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "South Africa",
+            "city": "Johannesburg",
+            "latitude": "-26.2347569",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Johannesburg, South Africa",
+            "region": "",
+            "longitude": "27.9826554"
+        },
+        "starts_at": "2022-10-01T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102988714?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-10-01T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102988714",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103476563?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Arab Emirates",
+            "city": "Dubai",
+            "latitude": "25.2037181",
+            "name": "Coca-Cola Arena",
+            "location": "Dubai, United Arab Emirates",
+            "region": "",
+            "longitude": "55.2657726"
+        },
+        "starts_at": "2022-10-08T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103476563?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-10-08T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103476563",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102993354?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Israel",
+            "city": "Tel Aviv-yafo",
+            "latitude": "32.100744",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Tel Aviv, Israel",
+            "region": "",
+            "longitude": "34.807026"
+        },
+        "starts_at": "2022-10-13T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102993354?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-10-13T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102993354",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103476576?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "India",
+            "city": "New Delhi",
+            "latitude": "28.5829595",
+            "name": "JLN Stadium Gate No 1",
+            "location": "New Delhi, India",
+            "region": "",
+            "longitude": "77.2312738"
+        },
+        "starts_at": "2022-10-18T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103476576?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-10-18T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103476576",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103298666?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Malaysia",
+            "city": "Kuala Lumpur",
+            "latitude": "3.054634900000001",
+            "name": "National Stadium Bukit Jalil",
+            "location": "Kuala Lumpur, Malaysia",
+            "region": "",
+            "longitude": "101.69134"
+        },
+        "starts_at": "2022-10-22T20:30:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103298666?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-10-22T20:30:00",
+        "on_sale_datetime": "",
+        "id": "103298666",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103368597?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Singapore",
+            "city": "Singapore",
+            "latitude": "1.304013",
+            "name": "National Stadium",
+            "location": "Singapore, Singapore",
+            "region": "",
+            "longitude": "103.8748426"
+        },
+        "starts_at": "2022-10-25T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103368597?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-10-25T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103368597",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103334728?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Indonesia",
+            "city": "Kota Jakarta Selatan",
+            "latitude": "-6.2173345",
+            "name": "GBK Madya Stadium",
+            "location": "Kota Administrasi Jakarta Selatan, Indonesia",
+            "region": "",
+            "longitude": "106.7995686"
+        },
+        "starts_at": "2022-11-02T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103334728?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-02T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103334728",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103298772?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Indonesia",
+            "city": "Kota Jakarta Selatan",
+            "latitude": "-6.2173345",
+            "name": "GBK Madya Stadium",
+            "location": "Kota Administrasi Jakarta Selatan, Indonesia",
+            "region": "",
+            "longitude": "106.7995686"
+        },
+        "starts_at": "2022-11-03T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103298772?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-03T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103298772",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103398652?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Thailand",
+            "city": "Khet Bang Kapi",
+            "latitude": "13.7554276",
+            "name": "Rajamangala Stadium",
+            "location": "Bang Kapi, Thailand",
+            "region": "",
+            "longitude": "100.622189"
+        },
+        "starts_at": "2022-11-06T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103398652?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-06T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103398652",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103258276?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "日本",
+            "city": "名古屋",
+            "latitude": "35.1865302",
+            "name": "Justice Tour",
+            "location": "日本名古屋",
+            "region": "",
+            "longitude": "136.94673549999993"
+        },
+        "starts_at": "2022-11-09T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justice Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103258276?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-09T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103258276",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103258543?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "日本",
+            "city": "西区",
+            "latitude": "34.6704093",
+            "name": "京セラドーム大阪",
+            "location": "日本西区",
+            "region": "",
+            "longitude": "135.47789569999998"
+        },
+        "starts_at": "2022-11-12T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103258543?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-12T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103258543",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "ローソンチケット",
+                "url": "https://www.bandsintown.com/bt/103298781?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&ticket_id=1586806438&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            },
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103298781?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&ticket_id=1879284650&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Japan",
+            "city": "Osaka",
+            "latitude": "34.6692804",
+            "name": "Kyocera Dome Osaka",
+            "location": "Osaka, Japan",
+            "region": "Osaka",
+            "longitude": "135.4761427"
+        },
+        "starts_at": "2022-11-13T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103298781?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-13T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103298781",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103258568?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&ticket_id=1878038047&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Japan",
+            "city": "Tokyo",
+            "latitude": "35.7034611",
+            "name": "Tokyo Dome",
+            "location": "Tokyo, Japan",
+            "region": "Tokyo",
+            "longitude": "139.7545086"
+        },
+        "starts_at": "2022-11-16T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103258568?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-16T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103258568",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "ローソンチケット",
+                "url": "https://www.bandsintown.com/bt/103258578?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&ticket_id=1585560145&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            },
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103258578?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&ticket_id=1878038357&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Japan",
+            "city": "Tokyo",
+            "latitude": "35.7034611",
+            "name": "Tokyo Dome",
+            "location": "Tokyo, Japan",
+            "region": "Tokyo",
+            "longitude": "139.7545086"
+        },
+        "starts_at": "2022-11-17T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103258578?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-17T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103258578",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102993622?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Australia",
+            "city": "Perth",
+            "latitude": "-31.9457767",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Perth, Australia",
+            "region": "",
+            "longitude": "115.86986130000003"
+        },
+        "starts_at": "2022-11-22T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102993622?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-22T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102993622",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102993625?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Australia",
+            "city": "Docklands",
+            "latitude": "-37.816518",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Docklands, Australia",
+            "region": "",
+            "longitude": "144.94554"
+        },
+        "starts_at": "2022-11-26T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102993625?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-26T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102993625",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102993629?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Australia",
+            "city": "Sydney",
+            "latitude": "-33.889067",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Sydney, Australia",
+            "region": "",
+            "longitude": "151.225364"
+        },
+        "starts_at": "2022-11-30T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102993629?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-11-30T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102993629",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102993630?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Australia",
+            "city": "Milton",
+            "latitude": "-27.464845",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Milton, Australia",
+            "region": "",
+            "longitude": "153.00953119999997"
+        },
+        "starts_at": "2022-12-03T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102993630?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-12-03T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102993630",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102993631?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "New Zealand",
+            "city": "Auckland",
+            "latitude": "-36.91828780000001",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Auckland, New Zealand",
+            "region": "",
+            "longitude": "174.81236869999998"
+        },
+        "starts_at": "2022-12-07T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102993631?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2022-12-07T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102993631",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103476588?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Netherlands",
+            "city": "Amsterdam",
+            "latitude": "52.3134245",
+            "name": "Ziggo Dome",
+            "location": "Amsterdam, Netherlands",
+            "region": "",
+            "longitude": "4.9371732"
+        },
+        "starts_at": "2023-01-11T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103476588?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-11T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103476588",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102988740?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Netherlands",
+            "city": "Amsterdam",
+            "latitude": "52.3134245",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Amsterdam, Netherlands",
+            "region": "",
+            "longitude": "4.9371732"
+        },
+        "starts_at": "2023-01-13T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102988740?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-13T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102988740",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103005162?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Netherlands",
+            "city": "Amsterdam",
+            "latitude": "52.3134245",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Amsterdam, Netherlands",
+            "region": "",
+            "longitude": "4.9371732"
+        },
+        "starts_at": "2023-01-14T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103005162?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-14T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103005162",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989808?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Germany",
+            "city": "Hamburg",
+            "latitude": "53.5893145",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Hamburg, Germany",
+            "region": "",
+            "longitude": "9.8992152"
+        },
+        "starts_at": "2023-01-16T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989808?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-16T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989808",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989814?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Switzerland",
+            "city": "Zürich",
+            "latitude": "47.410675",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Zürich, Switzerland",
+            "region": "",
+            "longitude": "8.552307"
+        },
+        "starts_at": "2023-01-18T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989814?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-18T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989814",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989819?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Portugal",
+            "city": "Lisboa",
+            "latitude": "38.7685312",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Lisbon, Portugal",
+            "region": "",
+            "longitude": "-9.0940297"
+        },
+        "starts_at": "2023-01-21T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989819?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-21T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989819",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989821?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Spain",
+            "city": "Madrid",
+            "latitude": "40.42387859999999",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Madrid, Spain",
+            "region": "",
+            "longitude": "-3.6717512"
+        },
+        "starts_at": "2023-01-23T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989821?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-23T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989821",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989822?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Spain",
+            "city": "Barcelona",
+            "latitude": "41.363225",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Barcelona, Spain",
+            "region": "",
+            "longitude": "2.1525678"
+        },
+        "starts_at": "2023-01-25T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989822?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-25T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989822",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989825?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Italy",
+            "city": "Casalecchio Di Reno",
+            "latitude": "44.4858777",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Casalecchio di Reno, Italy",
+            "region": "",
+            "longitude": "11.24816050000004"
+        },
+        "starts_at": "2023-01-27T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989825?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-27T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989825",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989827?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Italy",
+            "city": "Casalecchio Di Reno",
+            "latitude": "44.4858777",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Casalecchio di Reno, Italy",
+            "region": "",
+            "longitude": "11.24816050000004"
+        },
+        "starts_at": "2023-01-28T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989827?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-28T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989827",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989830?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Germany",
+            "city": "Cologne",
+            "latitude": "50.938546",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Köln, Germany",
+            "region": "",
+            "longitude": "6.979875"
+        },
+        "starts_at": "2023-01-31T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989830?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-01-31T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989830",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989832?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Germany",
+            "city": "Frankfurt Am Main",
+            "latitude": "50.113153",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Frankfurt am Main, Germany",
+            "region": "",
+            "longitude": "8.651284"
+        },
+        "starts_at": "2023-02-02T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989832?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-02T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989832",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989835?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Germany",
+            "city": "Berlin",
+            "latitude": "52.587992",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Berlin, Germany",
+            "region": "",
+            "longitude": "13.466292"
+        },
+        "starts_at": "2023-02-04T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989835?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-04T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989835",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989838?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Glasgow",
+            "latitude": "55.8600358",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Glasgow, United Kingdom",
+            "region": "",
+            "longitude": "-4.2854107"
+        },
+        "starts_at": "2023-02-08T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989838?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-08T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989838",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989841?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Aberdeen",
+            "latitude": "57.185629",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Aberdeen, United Kingdom",
+            "region": "",
+            "longitude": "-2.1932142"
+        },
+        "starts_at": "2023-02-11T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989841?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-11T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989841",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989842?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "London",
+            "latitude": "51.503038",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "London, United Kingdom",
+            "region": "",
+            "longitude": "0.0031543"
+        },
+        "starts_at": "2023-02-13T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989842?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-13T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989842",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989843?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "London",
+            "latitude": "51.503038",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "London, United Kingdom",
+            "region": "",
+            "longitude": "0.0031543"
+        },
+        "starts_at": "2023-02-14T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989843?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-14T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989843",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103005339?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "London",
+            "latitude": "51.503038",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "London, United Kingdom",
+            "region": "",
+            "longitude": "0.0031543"
+        },
+        "starts_at": "2023-02-16T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103005339?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-16T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103005339",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103476591?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "London",
+            "latitude": "51.503038",
+            "name": "The O2",
+            "location": "London, United Kingdom",
+            "region": "",
+            "longitude": "0.0031543"
+        },
+        "starts_at": "2023-02-17T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103476591?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-17T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103476591",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989848?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Birmingham",
+            "latitude": "52.44839899999999",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Birmingham, United Kingdom",
+            "region": "",
+            "longitude": "-1.7200959"
+        },
+        "starts_at": "2023-02-22T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989848?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-22T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989848",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103006132?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Birmingham",
+            "latitude": "52.44839899999999",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Birmingham, United Kingdom",
+            "region": "",
+            "longitude": "-1.7200959"
+        },
+        "starts_at": "2023-02-23T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103006132?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-23T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103006132",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989853?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Manchester",
+            "latitude": "53.4880988",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Manchester, United Kingdom",
+            "region": "",
+            "longitude": "-2.2436621"
+        },
+        "starts_at": "2023-02-25T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989853?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-25T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989853",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989855?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Sheffield",
+            "latitude": "53.399786",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Sheffield, United Kingdom",
+            "region": "",
+            "longitude": "-1.418825"
+        },
+        "starts_at": "2023-02-26T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989855?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-26T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989855",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103476601?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Ireland",
+            "city": "Dublin",
+            "latitude": "53.354771",
+            "name": "3Arena",
+            "location": "Dublin, Ireland",
+            "region": "",
+            "longitude": "-6.23234"
+        },
+        "starts_at": "2023-02-28T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103476601?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-02-28T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103476601",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103005342?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Manchester",
+            "latitude": "53.4880988",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Manchester, United Kingdom",
+            "region": "",
+            "longitude": "-2.2436621"
+        },
+        "starts_at": "2023-03-04T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103005342?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-04T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103005342",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103005341?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "United Kingdom",
+            "city": "Manchester",
+            "latitude": "53.4880988",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Manchester, United Kingdom",
+            "region": "",
+            "longitude": "-2.2436621"
+        },
+        "starts_at": "2023-03-04T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103005341?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-04T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103005341",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989865?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "France",
+            "city": "Paris",
+            "latitude": "48.83853789999999",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Paris, France",
+            "region": "",
+            "longitude": "2.3785841999999775"
+        },
+        "starts_at": "2023-03-06T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989865?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-06T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989865",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103005337?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "France",
+            "city": "Paris",
+            "latitude": "48.83853789999999",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Paris, France",
+            "region": "",
+            "longitude": "2.3785841999999775"
+        },
+        "starts_at": "2023-03-07T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103005337?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-07T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103005337",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989869?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Germany",
+            "city": "München",
+            "latitude": "48.1748152",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Munich, Germany",
+            "region": "",
+            "longitude": "11.5499705"
+        },
+        "starts_at": "2023-03-09T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989869?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-09T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989869",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989870?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Hungary",
+            "city": "Budapest",
+            "latitude": "47.5019",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Budapest, Hungary",
+            "region": "",
+            "longitude": "19.1054"
+        },
+        "starts_at": "2023-03-11T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989870?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-11T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989870",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989871?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Czech Republic",
+            "city": "Prague",
+            "latitude": "50.118729",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Prague, Czechia",
+            "region": "",
+            "longitude": "14.50591"
+        },
+        "starts_at": "2023-03-12T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989871?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-12T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989871",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989875?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Sweden",
+            "city": "Johanneshov",
+            "latitude": "59.29250219999999",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Johanneshov, Sweden",
+            "region": "",
+            "longitude": "18.0783105"
+        },
+        "starts_at": "2023-03-15T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989875?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-15T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989875",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989877?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Denmark",
+            "city": "København",
+            "latitude": "55.6254401",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Copenhagen, Denmark",
+            "region": "",
+            "longitude": "12.5737102"
+        },
+        "starts_at": "2023-03-17T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989877?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-17T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989877",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989878?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Denmark",
+            "city": "København",
+            "latitude": "55.6254401",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Copenhagen, Denmark",
+            "region": "",
+            "longitude": "12.5737102"
+        },
+        "starts_at": "2023-03-18T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989878?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-18T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989878",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989881?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Belgium",
+            "city": "Wilrijk",
+            "latitude": "51.23132",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Wilrijk, Belgium",
+            "region": "",
+            "longitude": "4.442688"
+        },
+        "starts_at": "2023-03-20T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989881?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-20T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989881",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103005163?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Belgium",
+            "city": "Wilrijk",
+            "latitude": "51.23132",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Wilrijk, Belgium",
+            "region": "",
+            "longitude": "4.442688"
+        },
+        "starts_at": "2023-03-21T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103005163?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-21T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103005163",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102989885?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Austria",
+            "city": "Vienna",
+            "latitude": "48.2019386",
+            "name": "Justin Bieber: Justice World Tour",
+            "location": "Vienna, Austria",
+            "region": "",
+            "longitude": "16.3316193"
+        },
+        "starts_at": "2023-03-24T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102989885?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-24T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102989885",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/102994334?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Poland",
+            "city": "Krakau",
+            "latitude": "50.0676558",
+            "name": "Justin Bieber: Justice World Tour ",
+            "location": "Kraków, Poland",
+            "region": "",
+            "longitude": "19.990720699999997"
+        },
+        "starts_at": "2023-03-25T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "Justin Bieber: Justice World Tour ",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/102994334?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-03-25T20:00:00",
+        "on_sale_datetime": "",
+        "id": "102994334",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103476624?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Philippines",
+            "city": "Pasay",
+            "latitude": "14.558412",
+            "name": "Cultural Center of the Philippines",
+            "location": "Pasay, Philippines",
+            "region": "",
+            "longitude": "120.985911"
+        },
+        "starts_at": "2023-10-29T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103476624?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-10-29T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103476624",
+        "ends_at": "",
+        "festival_end_date": ""
+    },
+    {
+        "offers": [
+            {
+                "type": "Tickets",
+                "url": "https://www.bandsintown.com/bt/103476618?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=ticket",
+                "status": "available"
+            }
+        ],
+        "venue": {
+            "country": "Australia",
+            "city": "Sydney",
+            "latitude": "-33.889067",
+            "name": "Allianz Stadium",
+            "location": "Sydney, Australia",
+            "region": "",
+            "longitude": "151.225364"
+        },
+        "starts_at": "2023-11-22T20:00:00",
+        "festival_datetime_display_rule": "",
+        "description": "",
+        "lineup": [
+            "Justin Bieber"
+        ],
+        "festival_start_date": "",
+        "bandsintown_plus": false,
+        "title": "",
+        "artist_id": "307871",
+        "url": "https://www.bandsintown.com/e/103476618?app_id=6e37869bb2e8504c0160c0ddcbd8c8aa&came_from=267&utm_medium=api&utm_source=public_api&utm_campaign=event",
+        "datetime_display_rule": "datetime",
+        "datetime": "2023-11-22T20:00:00",
+        "on_sale_datetime": "",
+        "id": "103476618",
+        "ends_at": "",
+        "festival_end_date": ""
+    }
+]

--- a/react-app/src/utilities/spotify-user-top-items.js
+++ b/react-app/src/utilities/spotify-user-top-items.js
@@ -1,4 +1,5 @@
 // https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks
+// https://developer.spotify.com/console/get-current-user-top-artists-and-tracks/
 
 export const spotifyUserTopItems = {
     "items": [

--- a/server/app.js
+++ b/server/app.js
@@ -1,12 +1,26 @@
+require('dotenv').config()
 var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
+var livereload = require("livereload");
+var connectLiveReload = require("connect-livereload");
 
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
+var bandsInTownRouter = require('./routes/bandsintown');
+
+const liveReloadServer = livereload.createServer();
+liveReloadServer.server.once("connection", () => {
+  setTimeout(() => {
+    liveReloadServer.refresh("/");
+  }, 100);
+});
+
 
 var app = express();
+
+app.use(connectLiveReload());
 
 app.use(logger('dev'));
 app.use(express.json());
@@ -16,5 +30,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
+app.use('/bandsintown', bandsInTownRouter);
 
 module.exports = app;

--- a/server/app.js
+++ b/server/app.js
@@ -20,14 +20,14 @@ liveReloadServer.server.once("connection", () => {
 
 
 var app = express();
-app.use(cors());
+app.use(cors({ credentials: true, origin: 'http://localhost:3000' }));
 
 app.use(connectLiveReload());
 
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
+app.use(cookieParser(process.env.COOKIE_SECRET));
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var livereload = require("livereload");
 var connectLiveReload = require("connect-livereload");
+const cors = require('cors');
 
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
@@ -19,6 +20,7 @@ liveReloadServer.server.once("connection", () => {
 
 
 var app = express();
+app.use(cors());
 
 app.use(connectLiveReload());
 

--- a/server/bin/www
+++ b/server/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.PORT || '3001');
 app.set('port', port);
 
 /**

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "cookie-parser": "~1.4.4",
+        "cors": "^2.8.5",
         "debug": "~2.6.9",
         "dotenv": "^16.0.1",
         "express": "~4.16.1",
@@ -469,6 +470,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -1307,6 +1320,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/on-finished": {
@@ -2277,6 +2298,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -2900,6 +2930,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,11 +8,45 @@
       "name": "server",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^0.27.2",
         "cookie-parser": "~1.4.4",
         "debug": "~2.6.9",
+        "dotenv": "^16.0.1",
         "express": "~4.16.1",
         "morgan": "~1.9.1"
+      },
+      "devDependencies": {
+        "connect-livereload": "^0.6.1",
+        "livereload": "^0.9.3",
+        "nodemon": "^2.0.18"
       }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -26,10 +60,76 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -40,6 +140,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/body-parser": {
@@ -62,12 +171,262 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/connect-livereload": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.6.1.tgz",
+      "integrity": "sha512-3R0kMOdL7CjJpU66fzAkCe6HNtd3AavCS4m+uW4KtJjrdGPT0SQEZieAYd+cm+lJoBznNQ4lqipYWkhBMgk00g==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/content-disposition": {
@@ -111,12 +470,56 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -132,10 +535,42 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
+      "dev": true
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -143,6 +578,24 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/escape-html": {
@@ -206,6 +659,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -223,6 +688,38 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -238,6 +735,111 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "dev": true,
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
     },
     "node_modules/http-errors": {
       "version": "1.6.3",
@@ -264,10 +866,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
+    "node_modules/import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -275,6 +910,223 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
+    },
+    "node_modules/is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+      "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "dependencies": {
+        "package-json": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/livereload": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.9.3.tgz",
+      "integrity": "sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.0",
+        "livereload-js": "^3.3.1",
+        "opts": ">= 1.2.0",
+        "ws": "^7.4.3"
+      },
+      "bin": {
+        "livereload": "bin/livereload.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/livereload-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-3.4.0.tgz",
+      "integrity": "sha512-F/pz9ZZP+R+arY94cECTZco7PXgBXyL+KVWUPZq8AQE9TOu14GV6fYeKOviv02JCvFa4Oi3Rs1hYEpfeajc+ow==",
+      "dev": true
+    },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/media-typer": {
@@ -325,6 +1177,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
     "node_modules/morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -353,6 +1232,83 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemon": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.18.tgz",
+      "integrity": "sha512-uAvrKipi2zAz8E7nkSz4qW4F4zd5fs2wNGsTx+xXlP8KXqd9ucE0vY9wankOsPboeDyuUGN9vsXGV1pLn80l/A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "pstree.remy": "^1.1.8",
+        "semver": "^5.7.1",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5",
+        "update-notifier": "^5.1.0"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/nodemon/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -372,6 +1328,54 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opts": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
+      "integrity": "sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==",
+      "dev": true
+    },
+    "node_modules/p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "dependencies": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -385,6 +1389,27 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -395,6 +1420,34 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "dependencies": {
+        "escape-goat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/qs": {
@@ -427,6 +1480,72 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+      "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+      "dev": true,
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -436,6 +1555,36 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/send": {
       "version": "0.16.2",
@@ -479,12 +1628,110 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "node_modules/statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "dependencies": {
+        "nopt": "~1.0.10"
+      },
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -499,12 +1746,94 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-notifier": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
+      "dev": true,
+      "dependencies": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.4",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/update-notifier/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+      "dev": true,
+      "dependencies": {
+        "prepend-http": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/utils-merge": {
@@ -522,9 +1851,113 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   },
   "dependencies": {
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -534,10 +1967,64 @@
         "negotiator": "0.6.3"
       }
     },
+    "ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -546,6 +2033,12 @@
       "requires": {
         "safe-buffer": "5.1.2"
       }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.18.3",
@@ -564,10 +2057,196 @@
         "type-is": "~1.6.16"
       }
     },
+    "boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        }
+      }
+    },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      }
+    },
+    "connect-livereload": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.6.1.tgz",
+      "integrity": "sha512-3R0kMOdL7CjJpU66fzAkCe6HNtd3AavCS4m+uW4KtJjrdGPT0SQEZieAYd+cm+lJoBznNQ4lqipYWkhBMgk00g==",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -598,6 +2277,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -605,6 +2290,32 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
+    "defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -616,15 +2327,56 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
     },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
+      "dev": true
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -680,6 +2432,15 @@
         }
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -694,6 +2455,21 @@
         "unpipe": "~1.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -703,6 +2479,83 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "global-dirs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "dev": true,
+      "requires": {
+        "ini": "2.0.0"
+      }
+    },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
+    },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
     },
     "http-errors": {
       "version": "1.6.3",
@@ -723,15 +2576,198 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
+    "ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      }
+    },
+    "is-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+      "dev": true
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "requires": {
+        "package-json": "^6.3.0"
+      }
+    },
+    "livereload": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.9.3.tgz",
+      "integrity": "sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.0",
+        "livereload-js": "^3.3.1",
+        "opts": ">= 1.2.0",
+        "ws": "^7.4.3"
+      }
+    },
+    "livereload-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-3.4.0.tgz",
+      "integrity": "sha512-F/pz9ZZP+R+arY94cECTZco7PXgBXyL+KVWUPZq8AQE9TOu14GV6fYeKOviv02JCvFa4Oi3Rs1hYEpfeajc+ow==",
+      "dev": true
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -766,6 +2802,27 @@
         "mime-db": "1.52.0"
       }
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -788,6 +2845,62 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
+    "nodemon": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.18.tgz",
+      "integrity": "sha512-uAvrKipi2zAz8E7nkSz4qW4F4zd5fs2wNGsTx+xXlP8KXqd9ucE0vY9wankOsPboeDyuUGN9vsXGV1pLn80l/A==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "pstree.remy": "^1.1.8",
+        "semver": "^5.7.1",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5",
+        "update-notifier": "^5.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -801,6 +2914,47 @@
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opts": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
+      "integrity": "sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==",
+      "dev": true
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
+    "package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -811,6 +2965,18 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -818,6 +2984,31 @@
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
+      }
+    },
+    "pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "requires": {
+        "escape-goat": "^2.0.0"
       }
     },
     "qs": {
@@ -841,6 +3032,62 @@
         "unpipe": "1.0.0"
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+          "dev": true
+        }
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "registry-auth-token": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+      "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.8"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -850,6 +3097,29 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "send": {
       "version": "0.16.2",
@@ -887,10 +3157,81 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -901,10 +3242,76 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^2.0.0"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "update-notifier": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.4",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -915,6 +3322,63 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.0.0"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "dev": true,
+      "requires": {}
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,8 @@
         "debug": "~2.6.9",
         "dotenv": "^16.0.1",
         "express": "~4.16.1",
-        "morgan": "~1.9.1"
+        "morgan": "~1.9.1",
+        "request": "^2.88.2"
       },
       "devDependencies": {
         "connect-livereload": "^0.6.1",
@@ -59,6 +60,21 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-align": {
@@ -112,10 +128,39 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axios": {
       "version": "0.27.2",
@@ -141,6 +186,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/binary-extensions": {
@@ -277,6 +330,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -471,6 +529,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -490,6 +553,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/debug": {
@@ -573,6 +647,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
       "dev": true
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -672,6 +755,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -718,6 +824,14 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/form-data": {
@@ -775,6 +889,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -830,6 +952,27 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -866,6 +1009,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
     "node_modules/iconv-lite": {
@@ -1037,8 +1194,7 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "node_modules/is-yarn-global": {
       "version": "0.3.0",
@@ -1046,11 +1202,50 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
     "node_modules/json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
       "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -1322,6 +1517,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1410,6 +1613,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1443,6 +1651,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -1457,6 +1670,14 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pupa": {
@@ -1558,6 +1779,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -1655,6 +1920,30 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -1742,6 +2031,34 @@
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
@@ -1845,6 +2162,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -1865,12 +2190,34 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/widest-line": {
@@ -1988,6 +2335,17 @@
         "negotiator": "0.6.3"
       }
     },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -2027,10 +2385,33 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
       "version": "0.27.2",
@@ -2053,6 +2434,14 @@
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "requires": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-extensions": {
@@ -2155,6 +2544,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -2298,6 +2692,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
     "cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -2312,6 +2711,14 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -2376,6 +2783,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==",
       "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2462,6 +2878,26 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2489,6 +2925,11 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
       "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -2524,6 +2965,14 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -2569,6 +3018,20 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2596,6 +3059,16 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -2716,8 +3189,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -2725,11 +3197,47 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
       "dev": true
+    },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
     },
     "keyv": {
       "version": "3.1.0",
@@ -2931,6 +3439,11 @@
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3000,6 +3513,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3021,6 +3539,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -3036,6 +3559,11 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -3112,6 +3640,45 @@
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "responselike": {
@@ -3198,6 +3765,22 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -3261,6 +3844,28 @@
       "requires": {
         "nopt": "~1.0.10"
       }
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "type-fest": {
       "version": "0.20.2",
@@ -3339,6 +3944,14 @@
         }
       }
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -3353,10 +3966,25 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "widest-line": {
       "version": "3.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^16.0.1",
     "express": "~4.16.1",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,8 @@
     "debug": "~2.6.9",
     "dotenv": "^16.0.1",
     "express": "~4.16.1",
-    "morgan": "~1.9.1"
+    "morgan": "~1.9.1",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "connect-livereload": "^0.6.1",

--- a/server/package.json
+++ b/server/package.json
@@ -3,12 +3,20 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "watch": "nodemon"
   },
   "dependencies": {
+    "axios": "^0.27.2",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
+    "dotenv": "^16.0.1",
     "express": "~4.16.1",
     "morgan": "~1.9.1"
+  },
+  "devDependencies": {
+    "connect-livereload": "^0.6.1",
+    "livereload": "^0.9.3",
+    "nodemon": "^2.0.18"
   }
 }

--- a/server/routes/bandsintown.js
+++ b/server/routes/bandsintown.js
@@ -34,7 +34,12 @@ router.get('/all-events', function (req, res, next) {
 
             return `https://rest.bandsintown.com/artists/${artistNameToQuery}/events?app_id=${process.env.BIT_API_KEY}&date=upcoming`
         })
-        let listOfArtists = spotifyData.map(artist => artist.name)
+        let listOfArtists = spotifyData.map(artist => ({
+            "name": artist.name,
+            "spotify_id": artist.id,
+            "spotify_url": artist.external_urls.spotify,
+            "image": artist.images[0].url
+        }))
 
 
 
@@ -55,7 +60,8 @@ router.get('/all-events', function (req, res, next) {
             result.forEach((promise, index) => {
 
                 if (promise.status == "rejected") {
-                    console.log(`Failed to find artist ${listOfArtists[index]}`)
+                    // have a list of failed to find artist b/c bandsintown doesn't have all artists
+                    console.log(`Failed to find artist ${listOfArtists[index].name}`)
                     failedToFindArtistList.push(listOfArtists[index])
                 } else if (promise.status == "fulfilled") {
 
@@ -66,9 +72,18 @@ router.get('/all-events', function (req, res, next) {
                         // Event is already in event list
                         if (foundEvent) {
                             // Foundevent doesn't include the artist already
-                            if (!foundEvent.lineup.find(element => { return element.toLowerCase() === listOfArtists[index].toLowerCase() }))
+                            if (!foundEvent.lineup.find(element => { return element.name.toLowerCase() === listOfArtists[index].name.toLowerCase() }))
                                 foundEvent.lineup.push(listOfArtists[index])
                         } else {
+                            // Overwite the lineup:["Dabin"] to lineup:[
+                            //     {
+                            //         "spotify_url": "https://open.spotify.com/artist/7lZauDnRoAC3kmaYae2opv",
+                            //         "id": "7lZauDnRoAC3kmaYae2opv",
+                            //         "image" : "https://i.scdn.co/image/ab6761610000e5ebdb691c4e0aff20504f6b6033",
+                            //         "name": "Dabin",
+                            //     }
+                            // ]
+                            eventValue.lineup = [listOfArtists[index]]
                             eventsList.push(eventValue)
                         }
                     })

--- a/server/routes/bandsintown.js
+++ b/server/routes/bandsintown.js
@@ -1,0 +1,878 @@
+var express = require('express');
+var router = express.Router();
+const https = require('https')
+const axios = require("axios");
+
+router.get('/artistevent', function (req, res, next) {
+
+    try {
+        axios.get(`https://rest.bandsintown.com/artists/illenium/events?app_id=${process.env.BIT_API_KEY}&date=upcoming`)
+            .then(response => {
+                res.send(response.data)
+            })
+            .catch(err => res.send(err));
+    }
+    catch (err) {
+        console.error("GG", err);
+    }
+
+});
+
+
+router.get('/all-events', function (req, res, next) {
+
+    try {
+
+        let artistEventRequestArray = spotifyData.map((artist) => {
+
+            let artistNameToQuery = artist.name
+
+            // This is for requests that bandsintown has a problem with...
+            if (artist.name == "Justin Bieber") {
+                artistNameToQuery = "JustinBieber"
+            }
+
+            return `https://rest.bandsintown.com/artists/${artistNameToQuery}/events?app_id=${process.env.BIT_API_KEY}&date=upcoming`
+        })
+        let listOfArtists = spotifyData.map(artist => artist.name)
+
+
+
+        async function start() {
+
+
+            const result = await Promise.allSettled(artistEventRequestArray.map((request) => {
+                return axios.get(request).then((response) => {
+                    return response.data;
+                }).then((data) => {
+                    return data;
+                });
+            }));
+            console.log(result.map(promise => promise.status));
+
+            let failedToFindArtistList = []
+            let eventsList = []
+
+            result.forEach((promise, index) => {
+
+                if (promise.status == "rejected") {
+                    console.log(`Failed to find artist ${listOfArtists[index]}`)
+                    failedToFindArtistList.push(listOfArtists[index])
+                } else if (promise.status == "fulfilled") {
+
+                    promise.value.forEach(eventValue => {
+
+                        const foundEvent = eventsList.find(event => event.title === eventValue.title);
+
+                        // Event is already in event list
+                        if (foundEvent) {
+                            foundEvent.lineup.push(listOfArtists[index])
+                        } else {
+                            eventsList.push(eventValue)
+                        }
+                    })
+
+                }
+
+
+            })
+
+            const finalObject = {
+                "eventsList": eventsList,
+                "failedToFindArtistList": failedToFindArtistList
+            }
+            res.set('Access-Control-Allow-Origin', '*');
+            res.send(finalObject)
+
+        }
+        start()
+
+    }
+    catch (err) {
+        console.error("GG", err);
+    }
+
+});
+
+
+module.exports = router;
+
+const spotifyData = [
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7lZauDnRoAC3kmaYae2opv"
+        },
+        "followers": {
+            "href": null,
+            "total": 132628
+        },
+        "genres": [
+            "canadian electronic",
+            "edm",
+            "electropop",
+            "future bass",
+            "melodic dubstep",
+            "pop dance",
+            "pop edm"
+        ],
+        "href": "https://api.spotify.com/v1/artists/7lZauDnRoAC3kmaYae2opv",
+        "id": "7lZauDnRoAC3kmaYae2opv",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebdb691c4e0aff20504f6b6033",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174db691c4e0aff20504f6b6033",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178db691c4e0aff20504f6b6033",
+                "width": 160
+            }
+        ],
+        "name": "Dabin",
+        "popularity": 55,
+        "type": "artist",
+        "uri": "spotify:artist:7lZauDnRoAC3kmaYae2opv"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0Y0QSi6lz1bPik5Ffjr8sd"
+        },
+        "followers": {
+            "href": null,
+            "total": 137271
+        },
+        "genres": [
+            "canadian electronic",
+            "edm",
+            "electro house",
+            "electronic trap",
+            "electropop",
+            "future bass",
+            "pop dance",
+            "pop edm",
+            "vapor twitch"
+        ],
+        "href": "https://api.spotify.com/v1/artists/0Y0QSi6lz1bPik5Ffjr8sd",
+        "id": "0Y0QSi6lz1bPik5Ffjr8sd",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb5944586f169166ac0a03735e",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051745944586f169166ac0a03735e",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1785944586f169166ac0a03735e",
+                "width": 160
+            }
+        ],
+        "name": "Ekali",
+        "popularity": 48,
+        "type": "artist",
+        "uri": "spotify:artist:0Y0QSi6lz1bPik5Ffjr8sd"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/45eNHdiiabvmbp4erw26rg"
+        },
+        "followers": {
+            "href": null,
+            "total": 1259989
+        },
+        "genres": [
+            "edm",
+            "melodic dubstep",
+            "pop",
+            "pop dance",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/45eNHdiiabvmbp4erw26rg",
+        "id": "45eNHdiiabvmbp4erw26rg",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb6b5fbf615ada187ce5e425c8",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051746b5fbf615ada187ce5e425c8",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1786b5fbf615ada187ce5e425c8",
+                "width": 160
+            }
+        ],
+        "name": "ILLENIUM",
+        "popularity": 72,
+        "type": "artist",
+        "uri": "spotify:artist:45eNHdiiabvmbp4erw26rg"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2ZRQcIgzPCVaT9XKhXZIzh"
+        },
+        "followers": {
+            "href": null,
+            "total": 819705
+        },
+        "genres": [
+            "dance pop",
+            "edm",
+            "pop",
+            "pop dance",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/2ZRQcIgzPCVaT9XKhXZIzh",
+        "id": "2ZRQcIgzPCVaT9XKhXZIzh",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb3438d570442b657621abc703",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051743438d570442b657621abc703",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1783438d570442b657621abc703",
+                "width": 160
+            }
+        ],
+        "name": "Gryffin",
+        "popularity": 71,
+        "type": "artist",
+        "uri": "spotify:artist:2ZRQcIgzPCVaT9XKhXZIzh"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0jNDKefhfSbLR9sFvcPLHo"
+        },
+        "followers": {
+            "href": null,
+            "total": 661924
+        },
+        "genres": [
+            "edm",
+            "electro house",
+            "electronic trap",
+            "electropop",
+            "future bass",
+            "pop dance",
+            "pop edm",
+            "vapor twitch"
+        ],
+        "href": "https://api.spotify.com/v1/artists/0jNDKefhfSbLR9sFvcPLHo",
+        "id": "0jNDKefhfSbLR9sFvcPLHo",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebbea280428d4ffabf1d7b0095",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174bea280428d4ffabf1d7b0095",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178bea280428d4ffabf1d7b0095",
+                "width": 160
+            }
+        ],
+        "name": "San Holo",
+        "popularity": 59,
+        "type": "artist",
+        "uri": "spotify:artist:0jNDKefhfSbLR9sFvcPLHo"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5JZ7CnR6gTvEMKX4g70Amv"
+        },
+        "followers": {
+            "href": null,
+            "total": 5045564
+        },
+        "genres": [
+            "dance pop",
+            "electropop",
+            "pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/5JZ7CnR6gTvEMKX4g70Amv",
+        "id": "5JZ7CnR6gTvEMKX4g70Amv",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb5af53f295e6c42529fbd0873",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051745af53f295e6c42529fbd0873",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1785af53f295e6c42529fbd0873",
+                "width": 160
+            }
+        ],
+        "name": "Lauv",
+        "popularity": 77,
+        "type": "artist",
+        "uri": "spotify:artist:5JZ7CnR6gTvEMKX4g70Amv"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/24V5UY0nChKpnb1TBPJhCw"
+        },
+        "followers": {
+            "href": null,
+            "total": 267359
+        },
+        "genres": [
+            "edm",
+            "electropop",
+            "future bass",
+            "indie poptimism",
+            "pop dance",
+            "pop edm",
+            "tropical house",
+            "vapor twitch"
+        ],
+        "href": "https://api.spotify.com/v1/artists/24V5UY0nChKpnb1TBPJhCw",
+        "id": "24V5UY0nChKpnb1TBPJhCw",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebe8e5902d8c4aacb792109f67",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174e8e5902d8c4aacb792109f67",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178e8e5902d8c4aacb792109f67",
+                "width": 160
+            }
+        ],
+        "name": "Jai Wolf",
+        "popularity": 55,
+        "type": "artist",
+        "uri": "spotify:artist:24V5UY0nChKpnb1TBPJhCw"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4LZ4De2MoO3lP6QaNCfvcu"
+        },
+        "followers": {
+            "href": null,
+            "total": 242907
+        },
+        "genres": [
+            "edm",
+            "electropop",
+            "future bass",
+            "melodic dubstep",
+            "pop dance",
+            "pop edm",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/4LZ4De2MoO3lP6QaNCfvcu",
+        "id": "4LZ4De2MoO3lP6QaNCfvcu",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebcd9e2b8f901285164a7fde6c",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174cd9e2b8f901285164a7fde6c",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178cd9e2b8f901285164a7fde6c",
+                "width": 160
+            }
+        ],
+        "name": "Said The Sky",
+        "popularity": 59,
+        "type": "artist",
+        "uri": "spotify:artist:4LZ4De2MoO3lP6QaNCfvcu"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/69GGBxA162lTqCwzJG5jLp"
+        },
+        "followers": {
+            "href": null,
+            "total": 19149394
+        },
+        "genres": [
+            "dance pop",
+            "edm",
+            "electropop",
+            "pop",
+            "pop dance",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/69GGBxA162lTqCwzJG5jLp",
+        "id": "69GGBxA162lTqCwzJG5jLp",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb3c02f4fb4cc9187c488afd50",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051743c02f4fb4cc9187c488afd50",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1783c02f4fb4cc9187c488afd50",
+                "width": 160
+            }
+        ],
+        "name": "The Chainsmokers",
+        "popularity": 80,
+        "type": "artist",
+        "uri": "spotify:artist:69GGBxA162lTqCwzJG5jLp"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2bWTIIQP9zaVc55RaMGu7e"
+        },
+        "followers": {
+            "href": null,
+            "total": 191728
+        },
+        "genres": [
+            "chill r&b",
+            "k-pop",
+            "korean r&b"
+        ],
+        "href": "https://api.spotify.com/v1/artists/2bWTIIQP9zaVc55RaMGu7e",
+        "id": "2bWTIIQP9zaVc55RaMGu7e",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebbbca2e91d07d2c53e6610570",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174bbca2e91d07d2c53e6610570",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178bbca2e91d07d2c53e6610570",
+                "width": 160
+            }
+        ],
+        "name": "Seori",
+        "popularity": 56,
+        "type": "artist",
+        "uri": "spotify:artist:2bWTIIQP9zaVc55RaMGu7e"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3fjs4zbBFxEFFe8Wyojo0G"
+        },
+        "followers": {
+            "href": null,
+            "total": 93887
+        },
+        "genres": [
+            "edm",
+            "electropop",
+            "future bass",
+            "indie poptimism",
+            "pop dance",
+            "pop edm",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3fjs4zbBFxEFFe8Wyojo0G",
+        "id": "3fjs4zbBFxEFFe8Wyojo0G",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb8e5e193ad94cafbd69cb12e4",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051748e5e193ad94cafbd69cb12e4",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1788e5e193ad94cafbd69cb12e4",
+                "width": 160
+            }
+        ],
+        "name": "Elephante",
+        "popularity": 50,
+        "type": "artist",
+        "uri": "spotify:artist:3fjs4zbBFxEFFe8Wyojo0G"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/21mKp7DqtSNHhCAU2ugvUw"
+        },
+        "followers": {
+            "href": null,
+            "total": 1393458
+        },
+        "genres": [
+            "chillwave",
+            "ninja"
+        ],
+        "href": "https://api.spotify.com/v1/artists/21mKp7DqtSNHhCAU2ugvUw",
+        "id": "21mKp7DqtSNHhCAU2ugvUw",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb1b00f0413d659ee91b505f70",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051741b00f0413d659ee91b505f70",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1781b00f0413d659ee91b505f70",
+                "width": 160
+            }
+        ],
+        "name": "ODESZA",
+        "popularity": 68,
+        "type": "artist",
+        "uri": "spotify:artist:21mKp7DqtSNHhCAU2ugvUw"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6KBy5qqU4Vvs8HkN1Ll2v4"
+        },
+        "followers": {
+            "href": null,
+            "total": 1890
+        },
+        "genres": [],
+        "href": "https://api.spotify.com/v1/artists/6KBy5qqU4Vvs8HkN1Ll2v4",
+        "id": "6KBy5qqU4Vvs8HkN1Ll2v4",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebc08ef9423f3c5c05a8f7e8d6",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174c08ef9423f3c5c05a8f7e8d6",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178c08ef9423f3c5c05a8f7e8d6",
+                "width": 160
+            }
+        ],
+        "name": "Stanford Lin",
+        "popularity": 25,
+        "type": "artist",
+        "uri": "spotify:artist:6KBy5qqU4Vvs8HkN1Ll2v4"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3HqSLMAZ3g3d5poNaI7GOU"
+        },
+        "followers": {
+            "href": null,
+            "total": 6999043
+        },
+        "genres": [
+            "k-pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3HqSLMAZ3g3d5poNaI7GOU",
+        "id": "3HqSLMAZ3g3d5poNaI7GOU",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb006ff3c0136a71bfb9928d34",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174006ff3c0136a71bfb9928d34",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178006ff3c0136a71bfb9928d34",
+                "width": 160
+            }
+        ],
+        "name": "IU",
+        "popularity": 71,
+        "type": "artist",
+        "uri": "spotify:artist:3HqSLMAZ3g3d5poNaI7GOU"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5w39eY1aNDybnDGTNgVt3r"
+        },
+        "followers": {
+            "href": null,
+            "total": 35183
+        },
+        "genres": [
+            "edm",
+            "electropop",
+            "pop dance",
+            "pop edm"
+        ],
+        "href": "https://api.spotify.com/v1/artists/5w39eY1aNDybnDGTNgVt3r",
+        "id": "5w39eY1aNDybnDGTNgVt3r",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb907bcb4ae15d53b6b218d582",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174907bcb4ae15d53b6b218d582",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178907bcb4ae15d53b6b218d582",
+                "width": 160
+            }
+        ],
+        "name": "Midnight Kids",
+        "popularity": 48,
+        "type": "artist",
+        "uri": "spotify:artist:5w39eY1aNDybnDGTNgVt3r"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6fcTRFpz0yH79qSKfof7lp"
+        },
+        "followers": {
+            "href": null,
+            "total": 425795
+        },
+        "genres": [
+            "dubstep",
+            "edm",
+            "electro house",
+            "melodic dubstep",
+            "pop dance",
+            "pop edm",
+            "progressive trance"
+        ],
+        "href": "https://api.spotify.com/v1/artists/6fcTRFpz0yH79qSKfof7lp",
+        "id": "6fcTRFpz0yH79qSKfof7lp",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb3a120b5c7fefeed869234a71",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051743a120b5c7fefeed869234a71",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1783a120b5c7fefeed869234a71",
+                "width": 160
+            }
+        ],
+        "name": "Seven Lions",
+        "popularity": 59,
+        "type": "artist",
+        "uri": "spotify:artist:6fcTRFpz0yH79qSKfof7lp"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7KC9q5wx0bxMD5ABgLCoEd"
+        },
+        "followers": {
+            "href": null,
+            "total": 91262
+        },
+        "genres": [
+            "bc underground hip hop",
+            "canadian contemporary r&b",
+            "trap soul"
+        ],
+        "href": "https://api.spotify.com/v1/artists/7KC9q5wx0bxMD5ABgLCoEd",
+        "id": "7KC9q5wx0bxMD5ABgLCoEd",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb3d78a9352ce74707da54a1ec",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051743d78a9352ce74707da54a1ec",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1783d78a9352ce74707da54a1ec",
+                "width": 160
+            }
+        ],
+        "name": "MANILA GREY",
+        "popularity": 48,
+        "type": "artist",
+        "uri": "spotify:artist:7KC9q5wx0bxMD5ABgLCoEd"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7hOGhpa8RMSuDOWntGIAJt"
+        },
+        "followers": {
+            "href": null,
+            "total": 386845
+        },
+        "genres": [
+            "electropop",
+            "indie poptimism",
+            "pop",
+            "pop dance",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/7hOGhpa8RMSuDOWntGIAJt",
+        "id": "7hOGhpa8RMSuDOWntGIAJt",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb8ec2cd2c426ae40191391487",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051748ec2cd2c426ae40191391487",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1788ec2cd2c426ae40191391487",
+                "width": 160
+            }
+        ],
+        "name": "A R I Z O N A",
+        "popularity": 60,
+        "type": "artist",
+        "uri": "spotify:artist:7hOGhpa8RMSuDOWntGIAJt"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0Ye4nfYAA91T1X56gnlXAA"
+        },
+        "followers": {
+            "href": null,
+            "total": 109425
+        },
+        "genres": [
+            "edm",
+            "electropop",
+            "indie poptimism",
+            "pop dance",
+            "pop edm",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/0Ye4nfYAA91T1X56gnlXAA",
+        "id": "0Ye4nfYAA91T1X56gnlXAA",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb504b0fca5641238b704b87f8",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174504b0fca5641238b704b87f8",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178504b0fca5641238b704b87f8",
+                "width": 160
+            }
+        ],
+        "name": "Mako",
+        "popularity": 62,
+        "type": "artist",
+        "uri": "spotify:artist:0Ye4nfYAA91T1X56gnlXAA"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1uNFoZAHBGtllmzznpCI3s"
+        },
+        "followers": {
+            "href": null,
+            "total": 61529310
+        },
+        "genres": [
+            "canadian pop",
+            "pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/1uNFoZAHBGtllmzznpCI3s",
+        "id": "1uNFoZAHBGtllmzznpCI3s",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb8ae7f2aaa9817a704a87ea36",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051748ae7f2aaa9817a704a87ea36",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1788ae7f2aaa9817a704a87ea36",
+                "width": 160
+            }
+        ],
+        "name": "Justin Bieber",
+        "popularity": 91,
+        "type": "artist",
+        "uri": "spotify:artist:1uNFoZAHBGtllmzznpCI3s"
+    }
+]

--- a/server/routes/bandsintown.js
+++ b/server/routes/bandsintown.js
@@ -21,26 +21,50 @@ router.get('/artistevent', function (req, res, next) {
 
 router.get('/all-events', function (req, res, next) {
 
+    console.log("If this is blank, you need to login. The cookies from all events is ", JSON.stringify(req.cookies.festivalFanatic.access_token))
+    let artistEventRequestArray = []
+    let listOfArtists = []
+
     try {
 
-        let artistEventRequestArray = spotifyData.map((artist) => {
-
-            let artistNameToQuery = artist.name
-
-            // This is for edge cases where bandsintown results are weird...
-            if (artist.name == "Justin Bieber") {
-                artistNameToQuery = "JustinBieber"
+        axios.get('https://api.spotify.com/v1/me/top/artists', {
+            headers: {
+                Authorization: 'Bearer ' + req.cookies.festivalFanatic.access_token //the token is a variable which holds the token
             }
+        }).then(spotifyResponse => {
+            // console.log("spotifyResponse.statusCode", spotifyResponse)
 
-            return `https://rest.bandsintown.com/artists/${artistNameToQuery}/events?app_id=${process.env.BIT_API_KEY}&date=upcoming`
-        })
-        let listOfArtists = spotifyData.map(artist => ({
-            "name": artist.name,
-            "spotify_id": artist.id,
-            "spotify_url": artist.external_urls.spotify,
-            "image": artist.images[0].url
-        }))
+            if (spotifyResponse.status == 200) {
 
+                // console.log(spotifyResponse.data.items)
+
+                artistEventRequestArray = spotifyResponse.data.items.map((artist) => {
+
+                    let artistNameToQuery = artist.name
+
+                    // This is for edge cases where bandsintown results are weird...
+                    if (artist.name == "Justin Bieber") {
+                        artistNameToQuery = "JustinBieber"
+                    }
+
+                    return `https://rest.bandsintown.com/artists/${artistNameToQuery}/events?app_id=${process.env.BIT_API_KEY}&date=upcoming`
+                })
+
+                listOfArtists = spotifyResponse.data.items.map(artist => ({
+                    "name": artist.name,
+                    "spotify_id": artist.id,
+                    // TODO: Temproairly taking this off cuz some artists don't have it, need to have a check
+                    // "spotify_url": artist.external_urls.spotify,
+                    // "image": artist.images[0].url
+                }))
+
+                start()
+
+
+            } else throw spotifyResponse.statusCode
+
+
+        }).catch(err => res.send(err));
 
 
         async function start() {
@@ -61,7 +85,6 @@ router.get('/all-events', function (req, res, next) {
 
                 if (promise.status == "rejected") {
                     // have a list of failed to find artist b/c bandsintown doesn't have all artists
-                    console.log(`Failed to find artist ${listOfArtists[index].name}`)
                     failedToFindArtistList.push(listOfArtists[index])
                 } else if (promise.status == "fulfilled") {
 
@@ -98,6 +121,9 @@ router.get('/all-events', function (req, res, next) {
 
             })
 
+            console.log(`Failed to find artists ${JSON.stringify(failedToFindArtistList.map(artist => artist.name))}`)
+
+
             const finalObject = {
                 "eventsList": eventsList,
                 "failedToFindArtistList": failedToFindArtistList
@@ -105,7 +131,7 @@ router.get('/all-events', function (req, res, next) {
             res.send(finalObject)
 
         }
-        start()
+
 
     }
     catch (err) {
@@ -124,7 +150,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 132628
+            "total": 133291
         },
         "genres": [
             "canadian electronic",
@@ -155,7 +181,7 @@ const spotifyData = [
             }
         ],
         "name": "Dabin",
-        "popularity": 55,
+        "popularity": 54,
         "type": "artist",
         "uri": "spotify:artist:7lZauDnRoAC3kmaYae2opv"
     },
@@ -165,7 +191,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 137271
+            "total": 137581
         },
         "genres": [
             "canadian electronic",
@@ -174,6 +200,7 @@ const spotifyData = [
             "electronic trap",
             "electropop",
             "future bass",
+            "melodic dubstep",
             "pop dance",
             "pop edm",
             "vapor twitch"
@@ -204,50 +231,11 @@ const spotifyData = [
     },
     {
         "external_urls": {
-            "spotify": "https://open.spotify.com/artist/45eNHdiiabvmbp4erw26rg"
-        },
-        "followers": {
-            "href": null,
-            "total": 1259989
-        },
-        "genres": [
-            "edm",
-            "melodic dubstep",
-            "pop",
-            "pop dance",
-            "tropical house"
-        ],
-        "href": "https://api.spotify.com/v1/artists/45eNHdiiabvmbp4erw26rg",
-        "id": "45eNHdiiabvmbp4erw26rg",
-        "images": [
-            {
-                "height": 640,
-                "url": "https://i.scdn.co/image/ab6761610000e5eb6b5fbf615ada187ce5e425c8",
-                "width": 640
-            },
-            {
-                "height": 320,
-                "url": "https://i.scdn.co/image/ab676161000051746b5fbf615ada187ce5e425c8",
-                "width": 320
-            },
-            {
-                "height": 160,
-                "url": "https://i.scdn.co/image/ab6761610000f1786b5fbf615ada187ce5e425c8",
-                "width": 160
-            }
-        ],
-        "name": "ILLENIUM",
-        "popularity": 72,
-        "type": "artist",
-        "uri": "spotify:artist:45eNHdiiabvmbp4erw26rg"
-    },
-    {
-        "external_urls": {
             "spotify": "https://open.spotify.com/artist/2ZRQcIgzPCVaT9XKhXZIzh"
         },
         "followers": {
             "href": null,
-            "total": 819705
+            "total": 823488
         },
         "genres": [
             "dance pop",
@@ -276,9 +264,48 @@ const spotifyData = [
             }
         ],
         "name": "Gryffin",
-        "popularity": 71,
+        "popularity": 70,
         "type": "artist",
         "uri": "spotify:artist:2ZRQcIgzPCVaT9XKhXZIzh"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/45eNHdiiabvmbp4erw26rg"
+        },
+        "followers": {
+            "href": null,
+            "total": 1264953
+        },
+        "genres": [
+            "edm",
+            "melodic dubstep",
+            "pop",
+            "pop dance",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/45eNHdiiabvmbp4erw26rg",
+        "id": "45eNHdiiabvmbp4erw26rg",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb6b5fbf615ada187ce5e425c8",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051746b5fbf615ada187ce5e425c8",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1786b5fbf615ada187ce5e425c8",
+                "width": 160
+            }
+        ],
+        "name": "ILLENIUM",
+        "popularity": 71,
+        "type": "artist",
+        "uri": "spotify:artist:45eNHdiiabvmbp4erw26rg"
     },
     {
         "external_urls": {
@@ -286,11 +313,10 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 661924
+            "total": 663179
         },
         "genres": [
             "edm",
-            "electro house",
             "electronic trap",
             "electropop",
             "future bass",
@@ -328,7 +354,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 5045564
+            "total": 5069647
         },
         "genres": [
             "dance pop",
@@ -365,7 +391,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 267359
+            "total": 268235
         },
         "genres": [
             "edm",
@@ -403,11 +429,89 @@ const spotifyData = [
     },
     {
         "external_urls": {
+            "spotify": "https://open.spotify.com/artist/60d24wfXkVzDSfLS6hyCjZ"
+        },
+        "followers": {
+            "href": null,
+            "total": 15571084
+        },
+        "genres": [
+            "dance pop",
+            "dutch edm",
+            "edm",
+            "electro house",
+            "pop",
+            "pop dance",
+            "progressive house",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/60d24wfXkVzDSfLS6hyCjZ",
+        "id": "60d24wfXkVzDSfLS6hyCjZ",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb66d17ee8690d2e8d94ee7387",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517466d17ee8690d2e8d94ee7387",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17866d17ee8690d2e8d94ee7387",
+                "width": 160
+            }
+        ],
+        "name": "Martin Garrix",
+        "popularity": 76,
+        "type": "artist",
+        "uri": "spotify:artist:60d24wfXkVzDSfLS6hyCjZ"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2bWTIIQP9zaVc55RaMGu7e"
+        },
+        "followers": {
+            "href": null,
+            "total": 195442
+        },
+        "genres": [
+            "k-pop",
+            "korean r&b"
+        ],
+        "href": "https://api.spotify.com/v1/artists/2bWTIIQP9zaVc55RaMGu7e",
+        "id": "2bWTIIQP9zaVc55RaMGu7e",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebbbca2e91d07d2c53e6610570",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174bbca2e91d07d2c53e6610570",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178bbca2e91d07d2c53e6610570",
+                "width": 160
+            }
+        ],
+        "name": "Seori",
+        "popularity": 56,
+        "type": "artist",
+        "uri": "spotify:artist:2bWTIIQP9zaVc55RaMGu7e"
+    },
+    {
+        "external_urls": {
             "spotify": "https://open.spotify.com/artist/4LZ4De2MoO3lP6QaNCfvcu"
         },
         "followers": {
             "href": null,
-            "total": 242907
+            "total": 244168
         },
         "genres": [
             "edm",
@@ -438,7 +542,7 @@ const spotifyData = [
             }
         ],
         "name": "Said The Sky",
-        "popularity": 59,
+        "popularity": 58,
         "type": "artist",
         "uri": "spotify:artist:4LZ4De2MoO3lP6QaNCfvcu"
     },
@@ -448,7 +552,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 19149394
+            "total": 19191758
         },
         "genres": [
             "dance pop",
@@ -484,54 +588,16 @@ const spotifyData = [
     },
     {
         "external_urls": {
-            "spotify": "https://open.spotify.com/artist/2bWTIIQP9zaVc55RaMGu7e"
-        },
-        "followers": {
-            "href": null,
-            "total": 191728
-        },
-        "genres": [
-            "chill r&b",
-            "k-pop",
-            "korean r&b"
-        ],
-        "href": "https://api.spotify.com/v1/artists/2bWTIIQP9zaVc55RaMGu7e",
-        "id": "2bWTIIQP9zaVc55RaMGu7e",
-        "images": [
-            {
-                "height": 640,
-                "url": "https://i.scdn.co/image/ab6761610000e5ebbbca2e91d07d2c53e6610570",
-                "width": 640
-            },
-            {
-                "height": 320,
-                "url": "https://i.scdn.co/image/ab67616100005174bbca2e91d07d2c53e6610570",
-                "width": 320
-            },
-            {
-                "height": 160,
-                "url": "https://i.scdn.co/image/ab6761610000f178bbca2e91d07d2c53e6610570",
-                "width": 160
-            }
-        ],
-        "name": "Seori",
-        "popularity": 56,
-        "type": "artist",
-        "uri": "spotify:artist:2bWTIIQP9zaVc55RaMGu7e"
-    },
-    {
-        "external_urls": {
             "spotify": "https://open.spotify.com/artist/3fjs4zbBFxEFFe8Wyojo0G"
         },
         "followers": {
             "href": null,
-            "total": 93887
+            "total": 94389
         },
         "genres": [
             "edm",
             "electropop",
             "future bass",
-            "indie poptimism",
             "pop dance",
             "pop edm",
             "tropical house"
@@ -556,9 +622,47 @@ const spotifyData = [
             }
         ],
         "name": "Elephante",
-        "popularity": 50,
+        "popularity": 49,
         "type": "artist",
         "uri": "spotify:artist:3fjs4zbBFxEFFe8Wyojo0G"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5w39eY1aNDybnDGTNgVt3r"
+        },
+        "followers": {
+            "href": null,
+            "total": 35334
+        },
+        "genres": [
+            "edm",
+            "electropop",
+            "pop dance",
+            "pop edm"
+        ],
+        "href": "https://api.spotify.com/v1/artists/5w39eY1aNDybnDGTNgVt3r",
+        "id": "5w39eY1aNDybnDGTNgVt3r",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb907bcb4ae15d53b6b218d582",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174907bcb4ae15d53b6b218d582",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178907bcb4ae15d53b6b218d582",
+                "width": 160
+            }
+        ],
+        "name": "Midnight Kids",
+        "popularity": 48,
+        "type": "artist",
+        "uri": "spotify:artist:5w39eY1aNDybnDGTNgVt3r"
     },
     {
         "external_urls": {
@@ -566,7 +670,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 1393458
+            "total": 1399914
         },
         "genres": [
             "chillwave",
@@ -602,7 +706,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 1890
+            "total": 1916
         },
         "genres": [],
         "href": "https://api.spotify.com/v1/artists/6KBy5qqU4Vvs8HkN1Ll2v4",
@@ -635,7 +739,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 6999043
+            "total": 7064672
         },
         "genres": [
             "k-pop"
@@ -660,47 +764,92 @@ const spotifyData = [
             }
         ],
         "name": "IU",
-        "popularity": 71,
+        "popularity": 70,
         "type": "artist",
         "uri": "spotify:artist:3HqSLMAZ3g3d5poNaI7GOU"
     },
     {
         "external_urls": {
-            "spotify": "https://open.spotify.com/artist/5w39eY1aNDybnDGTNgVt3r"
+            "spotify": "https://open.spotify.com/artist/1LOB7jTeEV14pHai6EXSzF"
         },
         "followers": {
             "href": null,
-            "total": 35183
+            "total": 655344
         },
         "genres": [
+            "dance pop",
             "edm",
+            "electro house",
             "electropop",
+            "electropowerpop",
+            "pop",
             "pop dance",
-            "pop edm"
+            "pop edm",
+            "tropical house"
         ],
-        "href": "https://api.spotify.com/v1/artists/5w39eY1aNDybnDGTNgVt3r",
-        "id": "5w39eY1aNDybnDGTNgVt3r",
+        "href": "https://api.spotify.com/v1/artists/1LOB7jTeEV14pHai6EXSzF",
+        "id": "1LOB7jTeEV14pHai6EXSzF",
         "images": [
             {
                 "height": 640,
-                "url": "https://i.scdn.co/image/ab6761610000e5eb907bcb4ae15d53b6b218d582",
+                "url": "https://i.scdn.co/image/ab6761610000e5eb580d49bdcc121033528ffaaf",
                 "width": 640
             },
             {
                 "height": 320,
-                "url": "https://i.scdn.co/image/ab67616100005174907bcb4ae15d53b6b218d582",
+                "url": "https://i.scdn.co/image/ab67616100005174580d49bdcc121033528ffaaf",
                 "width": 320
             },
             {
                 "height": 160,
-                "url": "https://i.scdn.co/image/ab6761610000f178907bcb4ae15d53b6b218d582",
+                "url": "https://i.scdn.co/image/ab6761610000f178580d49bdcc121033528ffaaf",
                 "width": 160
             }
         ],
-        "name": "Midnight Kids",
-        "popularity": 48,
+        "name": "Cash Cash",
+        "popularity": 63,
         "type": "artist",
-        "uri": "spotify:artist:5w39eY1aNDybnDGTNgVt3r"
+        "uri": "spotify:artist:1LOB7jTeEV14pHai6EXSzF"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0Ye4nfYAA91T1X56gnlXAA"
+        },
+        "followers": {
+            "href": null,
+            "total": 109613
+        },
+        "genres": [
+            "edm",
+            "electropop",
+            "indie poptimism",
+            "pop dance",
+            "pop edm",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/0Ye4nfYAA91T1X56gnlXAA",
+        "id": "0Ye4nfYAA91T1X56gnlXAA",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb504b0fca5641238b704b87f8",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174504b0fca5641238b704b87f8",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178504b0fca5641238b704b87f8",
+                "width": 160
+            }
+        ],
+        "name": "Mako",
+        "popularity": 61,
+        "type": "artist",
+        "uri": "spotify:artist:0Ye4nfYAA91T1X56gnlXAA"
     },
     {
         "external_urls": {
@@ -708,12 +857,13 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 425795
+            "total": 427111
         },
         "genres": [
             "dubstep",
             "edm",
             "electro house",
+            "future bass",
             "melodic dubstep",
             "pop dance",
             "pop edm",
@@ -749,7 +899,7 @@ const spotifyData = [
         },
         "followers": {
             "href": null,
-            "total": 91262
+            "total": 91734
         },
         "genres": [
             "bc underground hip hop",
@@ -782,11 +932,88 @@ const spotifyData = [
     },
     {
         "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1IueXOQyABrMOprrzwQJWN"
+        },
+        "followers": {
+            "href": null,
+            "total": 1432035
+        },
+        "genres": [
+            "dance pop",
+            "edm",
+            "house",
+            "pop",
+            "pop dance",
+            "tropical house",
+            "uk pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/1IueXOQyABrMOprrzwQJWN",
+        "id": "1IueXOQyABrMOprrzwQJWN",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb8422afa6e7b0c977636bfebd",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051748422afa6e7b0c977636bfebd",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1788422afa6e7b0c977636bfebd",
+                "width": 160
+            }
+        ],
+        "name": "Sigala",
+        "popularity": 73,
+        "type": "artist",
+        "uri": "spotify:artist:1IueXOQyABrMOprrzwQJWN"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1uNFoZAHBGtllmzznpCI3s"
+        },
+        "followers": {
+            "href": null,
+            "total": 62209532
+        },
+        "genres": [
+            "canadian pop",
+            "pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/1uNFoZAHBGtllmzznpCI3s",
+        "id": "1uNFoZAHBGtllmzznpCI3s",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb8ae7f2aaa9817a704a87ea36",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051748ae7f2aaa9817a704a87ea36",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1788ae7f2aaa9817a704a87ea36",
+                "width": 160
+            }
+        ],
+        "name": "Justin Bieber",
+        "popularity": 90,
+        "type": "artist",
+        "uri": "spotify:artist:1uNFoZAHBGtllmzznpCI3s"
+    },
+    {
+        "external_urls": {
             "spotify": "https://open.spotify.com/artist/7hOGhpa8RMSuDOWntGIAJt"
         },
         "followers": {
             "href": null,
-            "total": 386845
+            "total": 387677
         },
         "genres": [
             "electropop",
@@ -821,78 +1048,1043 @@ const spotifyData = [
     },
     {
         "external_urls": {
-            "spotify": "https://open.spotify.com/artist/0Ye4nfYAA91T1X56gnlXAA"
+            "spotify": "https://open.spotify.com/artist/20lmiQy576CSBPz0VJHmnC"
         },
         "followers": {
             "href": null,
-            "total": 109425
+            "total": 17437
         },
         "genres": [
-            "edm",
-            "electropop",
-            "indie poptimism",
+            "future bass",
+            "melodic dubstep",
             "pop dance",
-            "pop edm",
-            "tropical house"
+            "pop edm"
         ],
-        "href": "https://api.spotify.com/v1/artists/0Ye4nfYAA91T1X56gnlXAA",
-        "id": "0Ye4nfYAA91T1X56gnlXAA",
+        "href": "https://api.spotify.com/v1/artists/20lmiQy576CSBPz0VJHmnC",
+        "id": "20lmiQy576CSBPz0VJHmnC",
         "images": [
             {
                 "height": 640,
-                "url": "https://i.scdn.co/image/ab6761610000e5eb504b0fca5641238b704b87f8",
+                "url": "https://i.scdn.co/image/ab6761610000e5ebfc7e3afd7df90aed91c4de38",
                 "width": 640
             },
             {
                 "height": 320,
-                "url": "https://i.scdn.co/image/ab67616100005174504b0fca5641238b704b87f8",
+                "url": "https://i.scdn.co/image/ab67616100005174fc7e3afd7df90aed91c4de38",
                 "width": 320
             },
             {
                 "height": 160,
-                "url": "https://i.scdn.co/image/ab6761610000f178504b0fca5641238b704b87f8",
+                "url": "https://i.scdn.co/image/ab6761610000f178fc7e3afd7df90aed91c4de38",
                 "width": 160
             }
         ],
-        "name": "Mako",
-        "popularity": 62,
+        "name": "yetep",
+        "popularity": 42,
         "type": "artist",
-        "uri": "spotify:artist:0Ye4nfYAA91T1X56gnlXAA"
+        "uri": "spotify:artist:20lmiQy576CSBPz0VJHmnC"
     },
     {
         "external_urls": {
-            "spotify": "https://open.spotify.com/artist/1uNFoZAHBGtllmzznpCI3s"
+            "spotify": "https://open.spotify.com/artist/20DZAfCuP1TKZl5KcY7z3Q"
         },
         "followers": {
             "href": null,
-            "total": 61529310
+            "total": 359782
         },
         "genres": [
-            "canadian pop",
-            "pop"
+            "dubstep",
+            "edm",
+            "pop dance"
         ],
-        "href": "https://api.spotify.com/v1/artists/1uNFoZAHBGtllmzznpCI3s",
-        "id": "1uNFoZAHBGtllmzznpCI3s",
+        "href": "https://api.spotify.com/v1/artists/20DZAfCuP1TKZl5KcY7z3Q",
+        "id": "20DZAfCuP1TKZl5KcY7z3Q",
         "images": [
             {
                 "height": 640,
-                "url": "https://i.scdn.co/image/ab6761610000e5eb8ae7f2aaa9817a704a87ea36",
+                "url": "https://i.scdn.co/image/ab6761610000e5eb8ea9bed64e98b8ad91b1f98d",
                 "width": 640
             },
             {
                 "height": 320,
-                "url": "https://i.scdn.co/image/ab676161000051748ae7f2aaa9817a704a87ea36",
+                "url": "https://i.scdn.co/image/ab676161000051748ea9bed64e98b8ad91b1f98d",
                 "width": 320
             },
             {
                 "height": 160,
-                "url": "https://i.scdn.co/image/ab6761610000f1788ae7f2aaa9817a704a87ea36",
+                "url": "https://i.scdn.co/image/ab6761610000f1788ea9bed64e98b8ad91b1f98d",
                 "width": 160
             }
         ],
-        "name": "Justin Bieber",
-        "popularity": 91,
+        "name": "SLANDER",
+        "popularity": 67,
         "type": "artist",
-        "uri": "spotify:artist:1uNFoZAHBGtllmzznpCI3s"
+        "uri": "spotify:artist:20DZAfCuP1TKZl5KcY7z3Q"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/64KEffDW9EtZ1y2vBYgq8T"
+        },
+        "followers": {
+            "href": null,
+            "total": 33801242
+        },
+        "genres": [
+            "brostep",
+            "dance pop",
+            "edm",
+            "pop",
+            "pop dance",
+            "progressive electro house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/64KEffDW9EtZ1y2vBYgq8T",
+        "id": "64KEffDW9EtZ1y2vBYgq8T",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eba91af711541f8807ed7f0676",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174a91af711541f8807ed7f0676",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178a91af711541f8807ed7f0676",
+                "width": 160
+            }
+        ],
+        "name": "Marshmello",
+        "popularity": 81,
+        "type": "artist",
+        "uri": "spotify:artist:64KEffDW9EtZ1y2vBYgq8T"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7CajNmpbOovFoOoasH2HaY"
+        },
+        "followers": {
+            "href": null,
+            "total": 22808522
+        },
+        "genres": [
+            "dance pop",
+            "edm",
+            "electro house",
+            "house",
+            "pop",
+            "pop rap",
+            "progressive house",
+            "uk dance"
+        ],
+        "href": "https://api.spotify.com/v1/artists/7CajNmpbOovFoOoasH2HaY",
+        "id": "7CajNmpbOovFoOoasH2HaY",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb578905d5539cff25568dc097",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174578905d5539cff25568dc097",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178578905d5539cff25568dc097",
+                "width": 160
+            }
+        ],
+        "name": "Calvin Harris",
+        "popularity": 84,
+        "type": "artist",
+        "uri": "spotify:artist:7CajNmpbOovFoOoasH2HaY"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2p4FqHnazRucYQHyDCdBrJ"
+        },
+        "followers": {
+            "href": null,
+            "total": 3184744
+        },
+        "genres": [
+            "canadian pop punk",
+            "canadian punk",
+            "canadian rock",
+            "pop punk"
+        ],
+        "href": "https://api.spotify.com/v1/artists/2p4FqHnazRucYQHyDCdBrJ",
+        "id": "2p4FqHnazRucYQHyDCdBrJ",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb14be52ba7ed12e0177ebe08b",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517414be52ba7ed12e0177ebe08b",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17814be52ba7ed12e0177ebe08b",
+                "width": 160
+            }
+        ],
+        "name": "Simple Plan",
+        "popularity": 67,
+        "type": "artist",
+        "uri": "spotify:artist:2p4FqHnazRucYQHyDCdBrJ"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3dz0NnIZhtKKeXZxLOxCam"
+        },
+        "followers": {
+            "href": null,
+            "total": 995439
+        },
+        "genres": [
+            "complextro",
+            "edm",
+            "future bass",
+            "melodic dubstep",
+            "progressive electro house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3dz0NnIZhtKKeXZxLOxCam",
+        "id": "3dz0NnIZhtKKeXZxLOxCam",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb1804f56bdcb9322c5f3f8f21",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051741804f56bdcb9322c5f3f8f21",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1781804f56bdcb9322c5f3f8f21",
+                "width": 160
+            }
+        ],
+        "name": "Porter Robinson",
+        "popularity": 60,
+        "type": "artist",
+        "uri": "spotify:artist:3dz0NnIZhtKKeXZxLOxCam"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3Nrfpe0tUJi4K4DXYWgMUX"
+        },
+        "followers": {
+            "href": null,
+            "total": 51216191
+        },
+        "genres": [
+            "k-pop",
+            "k-pop boy group"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3Nrfpe0tUJi4K4DXYWgMUX",
+        "id": "3Nrfpe0tUJi4K4DXYWgMUX",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb5704a64f34fe29ff73ab56bb",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051745704a64f34fe29ff73ab56bb",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1785704a64f34fe29ff73ab56bb",
+                "width": 160
+            }
+        ],
+        "name": "BTS",
+        "popularity": 92,
+        "type": "artist",
+        "uri": "spotify:artist:3Nrfpe0tUJi4K4DXYWgMUX"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/23fqKkggKUBHNkbKtXEls4"
+        },
+        "followers": {
+            "href": null,
+            "total": 8061591
+        },
+        "genres": [
+            "edm",
+            "pop",
+            "pop dance",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/23fqKkggKUBHNkbKtXEls4",
+        "id": "23fqKkggKUBHNkbKtXEls4",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb6567299e3c53cf2a250fbdce",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051746567299e3c53cf2a250fbdce",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1786567299e3c53cf2a250fbdce",
+                "width": 160
+            }
+        ],
+        "name": "Kygo",
+        "popularity": 79,
+        "type": "artist",
+        "uri": "spotify:artist:23fqKkggKUBHNkbKtXEls4"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3hyEbRtp617pNCuuQjyOmc"
+        },
+        "followers": {
+            "href": null,
+            "total": 360085
+        },
+        "genres": [
+            "dance pop",
+            "edm",
+            "pop",
+            "pop dance",
+            "pop edm",
+            "pop rap",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3hyEbRtp617pNCuuQjyOmc",
+        "id": "3hyEbRtp617pNCuuQjyOmc",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eba143e59c7af9f75f44ffd6b2",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174a143e59c7af9f75f44ffd6b2",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178a143e59c7af9f75f44ffd6b2",
+                "width": 160
+            }
+        ],
+        "name": "Lost Kings",
+        "popularity": 59,
+        "type": "artist",
+        "uri": "spotify:artist:3hyEbRtp617pNCuuQjyOmc"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6eUKZXaKkcviH0Ku9w2n3V"
+        },
+        "followers": {
+            "href": null,
+            "total": 98801295
+        },
+        "genres": [
+            "pop",
+            "uk pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/6eUKZXaKkcviH0Ku9w2n3V",
+        "id": "6eUKZXaKkcviH0Ku9w2n3V",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb12a2ef08d00dd7451a6dbed6",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517412a2ef08d00dd7451a6dbed6",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17812a2ef08d00dd7451a6dbed6",
+                "width": 160
+            }
+        ],
+        "name": "Ed Sheeran",
+        "popularity": 90,
+        "type": "artist",
+        "uri": "spotify:artist:6eUKZXaKkcviH0Ku9w2n3V"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1bqxdqvUtPWZri43cKHac8"
+        },
+        "followers": {
+            "href": null,
+            "total": 748664
+        },
+        "genres": [
+            "australian pop",
+            "dance pop",
+            "electropop",
+            "pop",
+            "post-teen pop",
+            "viral pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/1bqxdqvUtPWZri43cKHac8",
+        "id": "1bqxdqvUtPWZri43cKHac8",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb09ce0644c08fa03347ef8928",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517409ce0644c08fa03347ef8928",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17809ce0644c08fa03347ef8928",
+                "width": 160
+            }
+        ],
+        "name": "MAX",
+        "popularity": 68,
+        "type": "artist",
+        "uri": "spotify:artist:1bqxdqvUtPWZri43cKHac8"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/04gDigrS5kc9YWfZHwBETP"
+        },
+        "followers": {
+            "href": null,
+            "total": 36797354
+        },
+        "genres": [
+            "pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/04gDigrS5kc9YWfZHwBETP",
+        "id": "04gDigrS5kc9YWfZHwBETP",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb288ac05481cedc5bddb5b11b",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174288ac05481cedc5bddb5b11b",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178288ac05481cedc5bddb5b11b",
+                "width": 160
+            }
+        ],
+        "name": "Maroon 5",
+        "popularity": 84,
+        "type": "artist",
+        "uri": "spotify:artist:04gDigrS5kc9YWfZHwBETP"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/053q0ukIDRgzwTr4vNSwab"
+        },
+        "followers": {
+            "href": null,
+            "total": 1700133
+        },
+        "genres": [
+            "art pop",
+            "canadian electropop",
+            "chillwave",
+            "dance pop",
+            "grave wave",
+            "indietronica",
+            "metropopolis",
+            "pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/053q0ukIDRgzwTr4vNSwab",
+        "id": "053q0ukIDRgzwTr4vNSwab",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb34771f759ca81a422f5f2b57",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517434771f759ca81a422f5f2b57",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17834771f759ca81a422f5f2b57",
+                "width": 160
+            }
+        ],
+        "name": "Grimes",
+        "popularity": 66,
+        "type": "artist",
+        "uri": "spotify:artist:053q0ukIDRgzwTr4vNSwab"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/4F5TrtYYxsVM1PhbtISE5m"
+        },
+        "followers": {
+            "href": null,
+            "total": 340125
+        },
+        "genres": [
+            "c-pop",
+            "cantopop",
+            "classic cantopop",
+            "hong kong rock"
+        ],
+        "href": "https://api.spotify.com/v1/artists/4F5TrtYYxsVM1PhbtISE5m",
+        "id": "4F5TrtYYxsVM1PhbtISE5m",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab67616d0000b27371befcc92c268193bdda52db",
+                "width": 640
+            },
+            {
+                "height": 300,
+                "url": "https://i.scdn.co/image/ab67616d00001e0271befcc92c268193bdda52db",
+                "width": 300
+            },
+            {
+                "height": 64,
+                "url": "https://i.scdn.co/image/ab67616d0000485171befcc92c268193bdda52db",
+                "width": 64
+            }
+        ],
+        "name": "Beyond",
+        "popularity": 52,
+        "type": "artist",
+        "uri": "spotify:artist:4F5TrtYYxsVM1PhbtISE5m"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1GxkXlMwML1oSg5eLPiAz3"
+        },
+        "followers": {
+            "href": null,
+            "total": 5316888
+        },
+        "genres": [
+            "adult standards",
+            "canadian pop",
+            "jazz pop",
+            "lounge"
+        ],
+        "href": "https://api.spotify.com/v1/artists/1GxkXlMwML1oSg5eLPiAz3",
+        "id": "1GxkXlMwML1oSg5eLPiAz3",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebef8cf61fea4923d2bde68200",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174ef8cf61fea4923d2bde68200",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178ef8cf61fea4923d2bde68200",
+                "width": 160
+            }
+        ],
+        "name": "Michael Bublé",
+        "popularity": 72,
+        "type": "artist",
+        "uri": "spotify:artist:1GxkXlMwML1oSg5eLPiAz3"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/41MozSoPIsD1dJM0CLPjZF"
+        },
+        "followers": {
+            "href": null,
+            "total": 30506583
+        },
+        "genres": [
+            "k-pop",
+            "k-pop girl group"
+        ],
+        "href": "https://api.spotify.com/v1/artists/41MozSoPIsD1dJM0CLPjZF",
+        "id": "41MozSoPIsD1dJM0CLPjZF",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb9f73197444a8a6b016f4a546",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051749f73197444a8a6b016f4a546",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1789f73197444a8a6b016f4a546",
+                "width": 160
+            }
+        ],
+        "name": "BLACKPINK",
+        "popularity": 78,
+        "type": "artist",
+        "uri": "spotify:artist:41MozSoPIsD1dJM0CLPjZF"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7n2wHs1TKAczGzO7Dd2rGr"
+        },
+        "followers": {
+            "href": null,
+            "total": 38214029
+        },
+        "genres": [
+            "canadian pop",
+            "pop",
+            "viral pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/7n2wHs1TKAczGzO7Dd2rGr",
+        "id": "7n2wHs1TKAczGzO7Dd2rGr",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb46e7a06fa6dfefaed6a3f0db",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517446e7a06fa6dfefaed6a3f0db",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17846e7a06fa6dfefaed6a3f0db",
+                "width": 160
+            }
+        ],
+        "name": "Shawn Mendes",
+        "popularity": 83,
+        "type": "artist",
+        "uri": "spotify:artist:7n2wHs1TKAczGzO7Dd2rGr"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5CiGnKThu5ctn9pBxv7DGa"
+        },
+        "followers": {
+            "href": null,
+            "total": 909502
+        },
+        "genres": [
+            "electropop",
+            "pop",
+            "pop rap"
+        ],
+        "href": "https://api.spotify.com/v1/artists/5CiGnKThu5ctn9pBxv7DGa",
+        "id": "5CiGnKThu5ctn9pBxv7DGa",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb766d2fb038033d3fbde69f89",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174766d2fb038033d3fbde69f89",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178766d2fb038033d3fbde69f89",
+                "width": 160
+            }
+        ],
+        "name": "benny blanco",
+        "popularity": 71,
+        "type": "artist",
+        "uri": "spotify:artist:5CiGnKThu5ctn9pBxv7DGa"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/5Rl15oVamLq7FbSb0NNBNy"
+        },
+        "followers": {
+            "href": null,
+            "total": 8617011
+        },
+        "genres": [
+            "boy band",
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/5Rl15oVamLq7FbSb0NNBNy",
+        "id": "5Rl15oVamLq7FbSb0NNBNy",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb5a3e65b6541c0ee57a5273c8",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051745a3e65b6541c0ee57a5273c8",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1785a3e65b6541c0ee57a5273c8",
+                "width": 160
+            }
+        ],
+        "name": "5 Seconds of Summer",
+        "popularity": 78,
+        "type": "artist",
+        "uri": "spotify:artist:5Rl15oVamLq7FbSb0NNBNy"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+        },
+        "followers": {
+            "href": null,
+            "total": 24399924
+        },
+        "genres": [
+            "big room",
+            "dance pop",
+            "edm",
+            "pop",
+            "pop dance",
+            "pop rap"
+        ],
+        "href": "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+        "id": "1Cs0zKBU1kc0i8ypK3B9ai",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb75348e1aade2645ad9c58829",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517475348e1aade2645ad9c58829",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17875348e1aade2645ad9c58829",
+                "width": 160
+            }
+        ],
+        "name": "David Guetta",
+        "popularity": 85,
+        "type": "artist",
+        "uri": "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/7d5SfGXKpgS3JK8BFIq59h"
+        },
+        "followers": {
+            "href": null,
+            "total": 76262
+        },
+        "genres": [
+            "edm",
+            "melodic dubstep",
+            "pop dance",
+            "pop edm"
+        ],
+        "href": "https://api.spotify.com/v1/artists/7d5SfGXKpgS3JK8BFIq59h",
+        "id": "7d5SfGXKpgS3JK8BFIq59h",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebb3b49b8fbf5fb73a02bb7565",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174b3b49b8fbf5fb73a02bb7565",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178b3b49b8fbf5fb73a02bb7565",
+                "width": 160
+            }
+        ],
+        "name": "William Black",
+        "popularity": 53,
+        "type": "artist",
+        "uri": "spotify:artist:7d5SfGXKpgS3JK8BFIq59h"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3WGpXCj9YhhfX11TToZcXP"
+        },
+        "followers": {
+            "href": null,
+            "total": 6876902
+        },
+        "genres": [
+            "australian pop",
+            "dance pop",
+            "pop",
+            "viral pop"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3WGpXCj9YhhfX11TToZcXP",
+        "id": "3WGpXCj9YhhfX11TToZcXP",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb002eedc44fefe085daae10e4",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174002eedc44fefe085daae10e4",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178002eedc44fefe085daae10e4",
+                "width": 160
+            }
+        ],
+        "name": "Troye Sivan",
+        "popularity": 77,
+        "type": "artist",
+        "uri": "spotify:artist:3WGpXCj9YhhfX11TToZcXP"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/0daugAjUgbJSqdlyYNwIbT"
+        },
+        "followers": {
+            "href": null,
+            "total": 403980
+        },
+        "genres": [
+            "edm",
+            "electro house",
+            "pop dance",
+            "pop edm",
+            "progressive electro house",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/0daugAjUgbJSqdlyYNwIbT",
+        "id": "0daugAjUgbJSqdlyYNwIbT",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb7478c400ce7d90d90b71e70b",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab676161000051747478c400ce7d90d90b71e70b",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f1787478c400ce7d90d90b71e70b",
+                "width": 160
+            }
+        ],
+        "name": "Vicetone",
+        "popularity": 63,
+        "type": "artist",
+        "uri": "spotify:artist:0daugAjUgbJSqdlyYNwIbT"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/1vCWHaC5f2uS3yhpwWbIA6"
+        },
+        "followers": {
+            "href": null,
+            "total": 21834238
+        },
+        "genres": [
+            "dance pop",
+            "edm",
+            "pop",
+            "pop dance",
+            "pop rap"
+        ],
+        "href": "https://api.spotify.com/v1/artists/1vCWHaC5f2uS3yhpwWbIA6",
+        "id": "1vCWHaC5f2uS3yhpwWbIA6",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb09bf4814c6585e1f69dfeef7",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517409bf4814c6585e1f69dfeef7",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17809bf4814c6585e1f69dfeef7",
+                "width": 160
+            }
+        ],
+        "name": "Avicii",
+        "popularity": 79,
+        "type": "artist",
+        "uri": "spotify:artist:1vCWHaC5f2uS3yhpwWbIA6"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/2qxJFvFYMEDqd7ui6kSAcq"
+        },
+        "followers": {
+            "href": null,
+            "total": 5767126
+        },
+        "genres": [
+            "complextro",
+            "dance pop",
+            "edm",
+            "electro house",
+            "electropop",
+            "german techno",
+            "pop",
+            "pop dance",
+            "pop rap",
+            "tropical house"
+        ],
+        "href": "https://api.spotify.com/v1/artists/2qxJFvFYMEDqd7ui6kSAcq",
+        "id": "2qxJFvFYMEDqd7ui6kSAcq",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5eb88d30a4c3e7d79a0cdfe96b3",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab6761610000517488d30a4c3e7d79a0cdfe96b3",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f17888d30a4c3e7d79a0cdfe96b3",
+                "width": 160
+            }
+        ],
+        "name": "Zedd",
+        "popularity": 74,
+        "type": "artist",
+        "uri": "spotify:artist:2qxJFvFYMEDqd7ui6kSAcq"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/3ApUX1o6oSz321MMECyIYd"
+        },
+        "followers": {
+            "href": null,
+            "total": 703133
+        },
+        "genres": [
+            "electropop",
+            "indie pop rap",
+            "pop",
+            "pop rap"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3ApUX1o6oSz321MMECyIYd",
+        "id": "3ApUX1o6oSz321MMECyIYd",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebc5bf602162d30b7133cfe96a",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174c5bf602162d30b7133cfe96a",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178c5bf602162d30b7133cfe96a",
+                "width": 160
+            }
+        ],
+        "name": "Quinn XCII",
+        "popularity": 67,
+        "type": "artist",
+        "uri": "spotify:artist:3ApUX1o6oSz321MMECyIYd"
+    },
+    {
+        "external_urls": {
+            "spotify": "https://open.spotify.com/artist/6vWDO969PvNqNYHIOW5v0m"
+        },
+        "followers": {
+            "href": null,
+            "total": 31552249
+        },
+        "genres": [
+            "dance pop",
+            "pop",
+            "r&b"
+        ],
+        "href": "https://api.spotify.com/v1/artists/6vWDO969PvNqNYHIOW5v0m",
+        "id": "6vWDO969PvNqNYHIOW5v0m",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/ab6761610000e5ebd3d058be8485c8583703b6d2",
+                "width": 640
+            },
+            {
+                "height": 320,
+                "url": "https://i.scdn.co/image/ab67616100005174d3d058be8485c8583703b6d2",
+                "width": 320
+            },
+            {
+                "height": 160,
+                "url": "https://i.scdn.co/image/ab6761610000f178d3d058be8485c8583703b6d2",
+                "width": 160
+            }
+        ],
+        "name": "Beyoncé",
+        "popularity": 82,
+        "type": "artist",
+        "uri": "spotify:artist:6vWDO969PvNqNYHIOW5v0m"
     }
 ]
+

--- a/server/routes/bandsintown.js
+++ b/server/routes/bandsintown.js
@@ -67,11 +67,11 @@ router.get('/all-events', function (req, res, next) {
 
                     promise.value.forEach(eventValue => {
 
-                        const foundEvent = eventsList.find(event => event.title === eventValue.title);
+                        const foundEvent = eventsList.find(eventInCurrentList => eventInCurrentList.title === eventValue.title);
 
                         // Event is already in event list
                         if (foundEvent) {
-                            // Foundevent doesn't include the artist already
+                            // Existing event found in current event list, just include it in the lineup
                             if (!foundEvent.lineup.find(element => { return element.name.toLowerCase() === listOfArtists[index].name.toLowerCase() }))
                                 foundEvent.lineup.push(listOfArtists[index])
                         } else {
@@ -84,6 +84,11 @@ router.get('/all-events', function (req, res, next) {
                             //     }
                             // ]
                             eventValue.lineup = [listOfArtists[index]]
+
+
+                            // Remove weird artist object from bandsintown API where it is always shown on first event found
+                            delete eventValue.artist
+
                             eventsList.push(eventValue)
                         }
                     })

--- a/server/routes/bandsintown.js
+++ b/server/routes/bandsintown.js
@@ -27,7 +27,7 @@ router.get('/all-events', function (req, res, next) {
 
             let artistNameToQuery = artist.name
 
-            // This is for requests that bandsintown has a problem with...
+            // This is for edge cases where bandsintown results are weird...
             if (artist.name == "Justin Bieber") {
                 artistNameToQuery = "JustinBieber"
             }
@@ -48,7 +48,6 @@ router.get('/all-events', function (req, res, next) {
                     return data;
                 });
             }));
-            console.log(result.map(promise => promise.status));
 
             let failedToFindArtistList = []
             let eventsList = []
@@ -66,7 +65,9 @@ router.get('/all-events', function (req, res, next) {
 
                         // Event is already in event list
                         if (foundEvent) {
-                            foundEvent.lineup.push(listOfArtists[index])
+                            // Foundevent doesn't include the artist already
+                            if (!foundEvent.lineup.find(element => { return element.toLowerCase() === listOfArtists[index].toLowerCase() }))
+                                foundEvent.lineup.push(listOfArtists[index])
                         } else {
                             eventsList.push(eventValue)
                         }
@@ -81,7 +82,6 @@ router.get('/all-events', function (req, res, next) {
                 "eventsList": eventsList,
                 "failedToFindArtistList": failedToFindArtistList
             }
-            res.set('Access-Control-Allow-Origin', '*');
             res.send(finalObject)
 
         }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,9 +1,161 @@
 var express = require('express');
 var router = express.Router();
+var request = require('request'); // "Request" library
 
 /* GET home page. */
-router.get('/', function(req, res, next) {
+router.get('/', function (req, res, next) {
   res.render('index', { title: 'Express' });
 });
+
+
+/**
+ * Generates a random string containing numbers and letters
+ * @param  {number} length The length of the string
+ * @return {string} The generated string
+ */
+var generateRandomString = function (length) {
+  var text = '';
+  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+  for (var i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+};
+
+var client_id = process.env.SPOTIFY_CLIENT_ID; // Your client id
+var client_secret = process.env.SPOTIFY_CLIENT_SECRET; // Your secret
+var redirect_uri = process.env.SPOTIFY_REDIRECT_URI; // Your redirect uri
+
+var stateKey = 'spotify_auth_state';
+
+router.get('/login', function (req, res, next) {
+  var state = generateRandomString(16);
+  res.cookie(stateKey, state);
+
+  // your application requests authorization
+  var scope = 'user-read-private user-top-read';
+  res.redirect('https://accounts.spotify.com/authorize?' +
+    new URLSearchParams({
+      response_type: 'code',
+      client_id: client_id,
+      scope: scope,
+      redirect_uri: redirect_uri,
+      state: state
+    }).toString());
+});
+
+router.get('/callback', function (req, res, next) {
+
+  // your application requests refresh and access tokens
+  // after checking the state parameter
+
+  var code = req.query.code || null;
+  var state = req.query.state || null;
+  var storedState = req.cookies ? req.cookies[stateKey] : null;
+
+  if (state === null || state !== storedState) {
+    res.redirect('/#' +
+      new URLSearchParams({
+        error: 'state_mismatch'
+      }).toString());
+  } else {
+    res.clearCookie(stateKey);
+    var authOptions = {
+      url: 'https://accounts.spotify.com/api/token',
+      form: {
+        code: code,
+        redirect_uri: redirect_uri,
+        grant_type: 'authorization_code'
+      },
+      headers: {
+        'Authorization': 'Basic ' + (new Buffer.from(client_id + ':' + client_secret).toString('base64'))
+      },
+      json: true
+    };
+
+    request.post(authOptions, function (error, response, body) {
+      if (!error && response.statusCode === 200) {
+
+        var access_token = body.access_token,
+          refresh_token = body.refresh_token;
+
+        var options = {
+          url: 'https://api.spotify.com/v1/me',
+          headers: { 'Authorization': 'Bearer ' + access_token },
+          json: true
+        };
+        // https://blog.logrocket.com/how-to-secure-react-app-login-authentication/
+        // https://dev.to/franciscomendes10866/using-cookies-with-jwt-in-node-js-8fn
+
+
+        // use the access token to access the Spotify Web API
+        request.get(options, function (error, response, body) {
+          console.log(body);
+        });
+
+        console.log(access_token)
+
+
+        const cookieOptions = {
+          // TODO: Enable it in production
+          httpOnly: true,
+          secure: true
+          // secure: process.env.NODE_ENV === "production",
+        };
+
+        res.cookie('festivalFanatic', {
+          access_token: access_token,
+          refresh_token: refresh_token
+        }, cookieOptions)
+
+
+        // we can also pass the token to the browser to make requests from there
+        res.redirect('http://localhost:3000/'
+
+
+        );
+      } else {
+        res.redirect('/#' +
+          new URLSearchParams({
+            error: 'invalid_token'
+          }).toString());
+      }
+    });
+  }
+});
+
+router.get('/checkcookie', function (req, res, next) {
+
+
+  try {
+    // const data = jwt.verify(token, "YOUR_SECRET_KEY");
+
+    const token = req.cookies.festivalFanatic.access_token;
+    console.log("The req cookie", req.cookies.festivalFanatic.access_token)
+    if (!token) {
+      return res.sendStatus(403);
+    }
+    console.log("The cookies are ", req.cookies.festivalFanatic)
+    return res.status(200).json({ message: "Your token is valid", cookie: req.cookies.festivalFanatic })
+    // Almost done
+  } catch {
+    return res.sendStatus(403);
+  }
+
+});
+
+router.get('/logout', function (req, res, next) {
+
+
+  res.clearCookie("festivalFanatic")
+
+
+  // const token = req.cookies.access_token;
+  res.redirect('https://accounts.spotify.com/en/logout')
+});
+
+
+
 
 module.exports = router;


### PR DESCRIPTION
## Context:
- Added redux skeleton to load festival dat
- Next, I will be making requests and such to spotify and potentially bandsintown if I have enough time to get some real data going
## Changes:
1. Added boilerplate for redux 
2. Added readme
3. Added logout button - it should clear cookies and revoke tokens through spotify's logout page
4. Top artists - uses hardcoded dummy data from spotify reducer
5. Results page - uses live data from festivals reducer. The "localhost:3001/bandsintown/all-events" request calls spotify and bandsintown (will need to separate later)
6. Added bandsintown-artist-event-RAW-data.js in case we lose access to API and need to demo
7. Added livereload upon saving a file
8. Added spotify oauth login to get access tokens to retrieve artists top tracks including session cookies to preserve data
9. Setup .env file to protect secrets
10. Sorting function to merge and clean up spotify data with bandsintown data to get all festivals with the lineups inside

## How to run
# Frontend, download docker desktop, run it, then open visual studio code
1. `cd react-app`
2. `npm i`
4. `npm start`

# Backend
1. Make sure you create the .env file in the server/.env
2. `cd server`
3. `npm i`
5. `npm run watch`


## Instructions to test
1. Once you have everything running, go to `localhost:3000`
2. Press login with spotify orange button
3. Use your real credentials from spotify and then go to `localhost:3000/results`
