### PR TITLE
Fix map bug

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -27,7 +27,8 @@
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "worker-loader": "^3.0.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -17507,6 +17508,25 @@
         "workbox-core": "6.5.3"
       }
     },
+    "node_modules/worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -30100,6 +30120,15 @@
       "requires": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.5.3"
+      }
+    },
+    "worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
       }
     },
     "wrap-ansi": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -22,7 +22,8 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "worker-loader": "^3.0.8"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/react-app/src/routes/detailed-results/detailed-results.jsx
+++ b/react-app/src/routes/detailed-results/detailed-results.jsx
@@ -7,8 +7,14 @@ import { BsCalendarFill } from "react-icons/bs";
 import { MdLocationPin } from "react-icons/md";
 import { GoLinkExternal } from "react-icons/go";
 import Map, { Marker } from "react-map-gl";
+import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
+
 import { apiBaseUrl, appBaseUrl } from "../../utilities/base-url";
+
+// eslint-disable-next-line import/no-webpack-loader-syntax
+mapboxgl.workerClass = require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
+
 
 export default function DetailedResults() {
   const location = useLocation();

--- a/react-app/src/routes/detailed-results/detailed-results.jsx
+++ b/react-app/src/routes/detailed-results/detailed-results.jsx
@@ -12,6 +12,7 @@ import "mapbox-gl/dist/mapbox-gl.css";
 
 import { apiBaseUrl, appBaseUrl } from "../../utilities/base-url";
 
+// Temp bug fix: https://github.com/visgl/react-map-gl/issues/1266#issuecomment-753686953
 // eslint-disable-next-line import/no-webpack-loader-syntax
 mapboxgl.workerClass = require("worker-loader!mapbox-gl/dist/mapbox-gl-csp-worker").default;
 


### PR DESCRIPTION
There is a known issue with mapbox where the latest version doesn't transpile properly on production builds of react apps.
This PR fixes the issue with this workaround: https://github.com/visgl/react-map-gl/issues/1266#issuecomment-753686953

To replicate:
- On develop cd into `react-app` run `npm run build` and serve your build
- Go into a detailed results page and notice the map is empty

before:
<img width="1417" alt="Screen Shot 2022-07-29 at 9 21 16 AM" src="https://user-images.githubusercontent.com/96637812/181815678-24c25548-132a-4996-b350-e832abf38eb7.png">

after:
<img width="1417" alt="Screen Shot 2022-07-29 at 9 21 06 AM" src="https://user-images.githubusercontent.com/96637812/181815783-34e91698-680d-439d-9028-100dc3a2cf41.png">


