### PR TITLE
Filter out past festivals

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,5 +31,5 @@ services:
     restart: unless-stopped
     ports:
       - 27017:27017
+      - 3000:3000
       - 3001:3001
-

--- a/server/models/Festival.js
+++ b/server/models/Festival.js
@@ -2,7 +2,7 @@ const mongoose = require("mongoose");
 
 const Festival = new mongoose.Schema({
   id: String,
-  date: String,
+  date: Date,
   name: String,
   city: String,
   region: String,

--- a/server/routes/festivals.js
+++ b/server/routes/festivals.js
@@ -3,27 +3,6 @@ const Festival = require("../models/Festival");
 var router = express.Router();
 const User = require("../models/User");
 
-/**
- * TODO need to include computed value of the length of intersection between artists and selectedArtists
- * This will allow sorting to happen on the database side, and also allow pagination for query optimization
- *
- * GET festivals that star artists in user's selectedArtist lineup
- **/
-router.get("/matched", async function (req, res, next) {
-  try {
-    const userId = req.session.user.userId;
-    const user = await User.findOne({ userId: userId });
-    const selectedArtists = user.selectedArtists;
-    const matchingFestivals = await Festival.find({
-      artists: { $in: selectedArtists },
-    });
-    res.send(matchingFestivals);
-  } catch (error) {
-    res.statusCode = 500;
-    res.send({ error: `unable to fetch matching festivals: ${error}` });
-  }
-});
-
 /** GET all the user's festivals including new matches, saved and archived festivals */
 router.get("/", async function (req, res, next) {
   try {
@@ -32,6 +11,7 @@ router.get("/", async function (req, res, next) {
     const selectedArtists = user.selectedArtists;
     const matchingFestivals = await Festival.find({
       artists: { $in: selectedArtists },
+      date: { $gt: new Date() }
     },{}, {lean: true});
     const userSavedList = user.saved;
     let savedFestivals = await Festival.find({ _id: { $in: userSavedList } }, {}, {lean: true});


### PR DESCRIPTION
### Work done
1. Added filter to festival endpoint to fetch only future festivals (saved and archived remain the same)
2. Removed /festivals/matched endpoint since no longer used

NOTE: may need to drop festivals collection and spotifyImports collection on production db since schema is changed (date is now Date instead of String)

### How to test
1. Update server env to connect to local db `MONGO_DB_CLUSTER=mongodb://festival-fanatic:password@localhost:27017/festival-fanatic
`
2. Run server with `npm run start:clean` 
3. Build frontend and login. Observe the festivals that are matched. If no festivals, use mock data.
4. Choose a festival to edit. Use the mongo extension to find the id.
5. Run `mongosh --username root --password password` to connect to local db
6. Run `use festival-fanatic` then `db.festivals.updateOne({ "id": IDOFFESTIVAL}, { $set: {"date": new Date("2022-08-02T19:30:00Z")}})` (replace IDOFFESTIVAL with id)
7. Reload the frontend window and observe that specific festival no longer appears.